### PR TITLE
Api Expert | Optimization

### DIFF
--- a/quyca/domain/helpers.py
+++ b/quyca/domain/helpers.py
@@ -1,5 +1,7 @@
-def get_works_h_index_by_scholar_citations(works: list) -> int:
-    citations = sorted([work.get("scholar_citations_count") for work in works], reverse=True)
+def get_works_h_index_by_scholar_citations(distribution: list[int]) -> int:
+    if not distribution:
+        return 0
+    citations = sorted(distribution, reverse=True)
     h_index = 0
     for i, cites in enumerate(citations):
         current_index = i + 1

--- a/quyca/domain/models/affiliation_model.py
+++ b/quyca/domain/models/affiliation_model.py
@@ -42,6 +42,18 @@ class Relation(BaseModel):
         return value
 
 
+class WorkType(BaseModel):
+    source: str | None = None
+    level: int | None = None
+    count: int | None = None
+
+
+class Work(BaseModel):
+    types: list[WorkType] | None = None
+    scholar_distribution: list[int] | None = Field(default=0)
+    source: list[dict] | None = None
+
+
 class Status(BaseModel):
     source: str | None
     status: str | None
@@ -52,7 +64,6 @@ class Affiliation(BaseModel):
     abbreviations: list[str] | None = None
     addresses: list[Address] | Address | None = None
     aliases: list[str] | None = None
-    birthdate: str | int | None = None
     citations_count: list[CitationsCount] | None = None
     description: list[Description] | None = None
     external_ids: list[ExternalId] | None = None
@@ -71,11 +82,31 @@ class Affiliation(BaseModel):
     logo: str | None = None
     affiliations: list[dict | Relation] | None = None
     relations_data: list[Relation] | None = None
+    works: list[Work] | None = None
+
+    @field_validator("names", mode="before")
+    @classmethod
+    def normalize_names(cls, value):
+        if not value:
+            return value
+
+        normalized = []
+        for item in value:
+            if isinstance(item, str):
+                normalized.append(Name(name=item, lang=None, source=None))
+            elif isinstance(item, dict):
+                normalized.append(Name(**item))
+            elif isinstance(item, Name):
+                normalized.append(item)
+        return normalized
 
     @model_validator(mode="after")
-    def get_name(self):  # type: ignore
-        es_name = next(filter(lambda x: x.lang == "es", self.names), None)
-        self.name = es_name.name if es_name else self.names[0].name
+    def get_name(self):
+        if self.names:
+            es_name = next(filter(lambda x: x.lang == "es", self.names), None)
+            self.name = es_name.name if es_name else self.names[0].name
+        else:
+            self.name = None
         return self
 
     class Config:

--- a/quyca/domain/models/base_model.py
+++ b/quyca/domain/models/base_model.py
@@ -239,6 +239,15 @@ class Author(BaseModel):
             )
         )
 
+    @field_validator("affiliations", mode="before")
+    @classmethod
+    def ensure_list_affiliations(cls, value):
+        if value is None:
+            return []
+        if isinstance(value, dict):
+            return [value]
+        return value
+
     @model_validator(mode="after")
     def compute_age_and_remove_birthdate(self):
         if self.birthdate:
@@ -260,6 +269,8 @@ class Author(BaseModel):
 class Group(BaseModel):
     id: str | None = None
     name: str | None
+    ranking: str | None = None
+    citations_count: list[CitationsCount] | None = None
 
     class Config:
         json_encoders = {ObjectId: str}

--- a/quyca/domain/models/base_model.py
+++ b/quyca/domain/models/base_model.py
@@ -241,7 +241,6 @@ class Author(BaseModel):
 
     @model_validator(mode="after")
     def compute_age_and_remove_birthdate(self):
-        print("bday", self.birthdate)
         if self.birthdate:
             try:
                 birth_ts = int(self.birthdate)

--- a/quyca/domain/models/person_model.py
+++ b/quyca/domain/models/person_model.py
@@ -112,10 +112,10 @@ class Person(BaseModel):
         if self.birthdate:
             try:
                 if isinstance(self.birthdate, int):
-                    # Si es timestamp en segundos
+                    # If it is a timestamp in seconds
                     birth_date = datetime.fromtimestamp(self.birthdate).date()
                 elif isinstance(self.birthdate, str):
-                    # Intentar parsear como fecha YYYY-MM-DD
+                    # Try to parse as date YYYY-MM-DD
                     birth_date = datetime.fromisoformat(self.birthdate).date()
                 else:
                     return self
@@ -136,5 +136,12 @@ class Person(BaseModel):
     @model_validator(mode="after")
     def get_logo(self) -> "Person":
         if self.affiliations_data:
-            self.logo = next(filter(lambda x: x.source == "logo", self.affiliations_data[0].external_urls)).url  # type: ignore
+            external_urls = (
+                self.affiliations_data[0].external_urls
+                if self.affiliations_data[0] and self.affiliations_data[0].external_urls
+                else []
+            )
+            logo = next((x for x in external_urls if x.source == "logo"), None)
+            if logo:
+                self.logo = str(logo.url)
         return self

--- a/quyca/domain/models/person_model.py
+++ b/quyca/domain/models/person_model.py
@@ -109,7 +109,6 @@ class Person(BaseModel):
 
     @model_validator(mode="after")
     def calculate_age(self) -> "Person":
-        print(self.birthdate)
         if self.birthdate:
             try:
                 if isinstance(self.birthdate, int):

--- a/quyca/domain/models/work_model.py
+++ b/quyca/domain/models/work_model.py
@@ -87,7 +87,7 @@ class Work(BaseModel):
     abstracts: list[Abstract] | None = None
     apc: APC | None = Field(default_factory=APC)
     authors_count: int | None = Field(default_factory=int, alias="author_count")
-    authors: list[AutorWork] | str | None = Field(default_factory=list[AutorWork])
+    authors: list[Author] = Field(default_factory=list)
     bibliographic_info: BiblioGraphicInfo | None = None
     citations: list | None = Field(default_factory=list)
     citations_by_year: list[CitationByYear] | None = None

--- a/quyca/domain/parsers/affiliation_parser.py
+++ b/quyca/domain/parsers/affiliation_parser.py
@@ -1,4 +1,9 @@
-def parse_search_result(affiliations: list) -> list:
+from typing import List
+
+from quyca.domain.models.base_model import Affiliation
+
+
+def parse_search_result(affiliations: List) -> List[Affiliation]:
     include = [
         "id",
         "addresses",

--- a/quyca/domain/parsers/bar_parser.py
+++ b/quyca/domain/parsers/bar_parser.py
@@ -88,8 +88,9 @@ def parse_annual_apc_expenses(works: Generator) -> dict:
     currency_converter = CurrencyConverter()
     for work in works:
         total_results += 1
-        apc_charges = work.source.apc.charges
-        apc_currency = work.source.apc.currency
+        source_apc = getattr(work.source, "apc", None)
+        apc_charges = getattr(source_apc, "charges", None)
+        apc_currency = getattr(source_apc, "currency", None)
         if not apc_charges or not apc_currency or apc_currency in ["IRR", "NGN"]:
             continue
         usd_charges = currency_converter.convert(apc_charges, apc_currency, "USD")

--- a/quyca/domain/parsers/pie_parser.py
+++ b/quyca/domain/parsers/pie_parser.py
@@ -161,10 +161,11 @@ def parse_articles_by_scimago_quartile(works: Generator) -> list:
     total_articles = 0
     for work in works:
         total_articles += 1
-        work_date = work.date_published
+        work_date = getattr(work, "date_published", None)
         if not work_date:
             continue
-        for ranking in work.source.ranking:
+        source_rankings = getattr(work.source, "ranking", None) or []
+        for ranking in source_rankings:
             if (
                 ranking.source in valid_sources
                 and ranking.rank != "-"

--- a/quyca/domain/parsers/source_parser.py
+++ b/quyca/domain/parsers/source_parser.py
@@ -16,7 +16,7 @@ def parse_search_result(sources: List) -> List:
         A list of dictionaries containing the relevant fields from each source entity.
     """
     source_fields = [
-        "_id",
+        "id",
         "updated",
         "names",
         "abbreviations",

--- a/quyca/domain/services/affiliation_plot_service.py
+++ b/quyca/domain/services/affiliation_plot_service.py
@@ -128,11 +128,10 @@ def plot_annual_articles_open_access(affiliation_id: str, query_params: QueryPar
 
 def plot_annual_articles_by_top_publishers(affiliation_id: str, query_params: QueryParams) -> dict:
     pipeline_params = {
-        "source_project": ["publisher"],
-        "work_project": ["source", "year_published", "types"],
+        "work_project": ["source.name", "source.publisher.name", "source.id", "year_published", "types"],
         "match": {
             "types.type": {"$in": articles_types_list},
-            "source.publisher.name": {"$ne": float("nan")},
+            "source.publisher.name": {"$ne": None},
         },
     }
     works = work_repository.get_works_with_source_by_affiliation(affiliation_id, query_params, pipeline_params)
@@ -146,8 +145,7 @@ def plot_most_used_title_words(affiliation_id: str, query_params: QueryParams) -
 
 def plot_articles_by_publisher(affiliation_id: str, query_params: QueryParams) -> dict:
     pipeline_params = {
-        "source_project": ["publisher"],
-        "work_project": ["source"],
+        "work_project": ["source.id", "source.publisher.name", "source.name"],
         "match": {"types.type": {"$in": articles_types_list}},
     }
     works = work_repository.get_works_with_source_by_affiliation(affiliation_id, query_params, pipeline_params)
@@ -198,8 +196,7 @@ def plot_articles_by_scienti_category(affiliation_id: str, query_params: QueryPa
 
 def plot_articles_by_scimago_quartile(affiliation_id: str, query_params: QueryParams) -> dict:
     pipeline_params = {
-        "source_project": ["ranking"],
-        "work_project": ["source", "date_published"],
+        "work_project": ["source.id", "source.name", "date_published", "source.ranking"],
         "match": {"types.type": {"$in": articles_types_list}},
     }
     works = work_repository.get_works_with_source_by_affiliation(affiliation_id, query_params, pipeline_params)
@@ -209,8 +206,7 @@ def plot_articles_by_scimago_quartile(affiliation_id: str, query_params: QueryPa
 def plot_articles_by_publishing_institution(affiliation_id: str, query_params: QueryParams) -> dict:
     institution = affiliation_repository.get_affiliation_by_id(affiliation_id)
     pipeline_params = {
-        "source_project": ["publisher"],
-        "work_project": ["source"],
+        "work_project": ["source.id", "source.name", "source.publisher.name"],
         "match": {"types.type": {"$in": articles_types_list}},
     }
     works = work_repository.get_works_with_source_by_affiliation(affiliation_id, query_params, pipeline_params)
@@ -233,6 +229,6 @@ def plot_institutional_coauthorship_network(affiliation_id: str, query_params: Q
 
 
 def plot_annual_apc_expenses(affiliation_id: str, query_params: QueryParams) -> dict:
-    pipeline_params = {"source_project": ["apc"], "work_project": ["source", "year_published"]}
+    pipeline_params = {"work_project": ["source.id", "source.name", "source.apc", "year_published"]}
     works = work_repository.get_works_with_source_by_affiliation(affiliation_id, query_params, pipeline_params)
     return bar_parser.parse_annual_apc_expenses(works)

--- a/quyca/domain/services/affiliation_plot_service.py
+++ b/quyca/domain/services/affiliation_plot_service.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from pymongo.command_cursor import CommandCursor
 
 from quyca.domain.constants.articles_types import articles_types_list
@@ -19,37 +18,36 @@ from quyca.domain.parsers import (
 
 
 def get_affiliation_plot(affiliation_id: str, affiliation_type: str, query_params: QueryParams) -> dict | None:
-    """
-    Get the affiliation plot data based on the affiliation ID, type, and query parameters. Using a mapping that associates plot types to their corresponding functions and whether they require relation_type.
-    """
     plot_type = query_params.plot
-
-    plot_map: dict[str, tuple[Callable, bool]] = {
-        "faculties_by_product_type": (plot_affiliations_by_product_type, True),
-        "departments_by_product_type": (plot_affiliations_by_product_type, True),
-        "research_groups_by_product_type": (plot_affiliations_by_product_type, True),
-        "citations_by_faculty": (plot_citations_by_affiliations, True),
-        "citations_by_department": (plot_citations_by_affiliations, True),
-        "citations_by_research_group": (plot_citations_by_affiliations, True),
-        "apc_expenses_by_faculty": (plot_apc_expenses_by_affiliation, True),
-        "apc_expenses_by_department": (plot_apc_expenses_by_affiliation, True),
-        "apc_expenses_by_group": (plot_apc_expenses_by_affiliation, True),
-        "h_index_by_faculty": (plot_h_index_by_affiliation, True),
-        "h_index_by_department": (plot_h_index_by_affiliation, True),
-        "h_index_by_research_group": (plot_h_index_by_affiliation, True),
+    plot_type_dict = {
+        "faculties_by_product_type": "faculty",
+        "departments_by_product_type": "department",
+        "research_groups_by_product_type": "group",
     }
-
-    if plot_type in plot_map:
-        func, need_relation = plot_map[plot_type]
-        relation_type = plot_type.split("_")[-1] if need_relation else None
-
-        if func is plot_affiliations_by_product_type:
-            return func(affiliation_id, affiliation_type, relation_type, query_params)
-        if func in (plot_apc_expenses_by_affiliation, plot_h_index_by_affiliation):
-            return func(affiliation_id, affiliation_type, relation_type, query_params)
-        if func is plot_citations_by_affiliations:
-            return func(affiliation_id, affiliation_type, relation_type)
-
+    if plot_type is not None and plot_type in plot_type_dict.keys():
+        relation_type = plot_type_dict[plot_type]
+        return plot_affiliations_by_product_type(affiliation_id, affiliation_type, relation_type, query_params)
+    if plot_type in [
+        "citations_by_faculty",
+        "citations_by_department",
+        "citations_by_research_group",
+    ]:
+        relation_type = plot_type.split("_")[-1]
+        return plot_citations_by_affiliations(affiliation_id, affiliation_type, relation_type)
+    if plot_type in [
+        "apc_expenses_by_faculty",
+        "apc_expenses_by_department",
+        "apc_expenses_by_group",
+    ]:
+        relation_type = plot_type.split("_")[-1]
+        return plot_apc_expenses_by_affiliation(affiliation_id, affiliation_type, relation_type, query_params)
+    if plot_type in [
+        "h_index_by_faculty",
+        "h_index_by_department",
+        "h_index_by_research_group",
+    ]:
+        relation_type = plot_type.split("_")[-1]
+        return plot_h_index_by_affiliation(affiliation_id, affiliation_type, relation_type, query_params)
     return globals().get(f"plot_{plot_type}", lambda *_: None)(affiliation_id, query_params)
 
 

--- a/quyca/domain/services/affiliation_service.py
+++ b/quyca/domain/services/affiliation_service.py
@@ -48,18 +48,24 @@ def get_related_affiliations_by_affiliation(affiliation_id: str, affiliation_typ
 
 def search_affiliations(affiliation_type: str, query_params: QueryParams) -> dict:
     pipeline_params = {
-        "project": [
-            "_id",
-            "names",
-            "addresses.country_code",
-            "external_ids",
-            "external_urls",
-            "relations",
-            "types",
-            "citations_count",
-            "products_count",
-            "relations_data",
-        ]
+        "project": {
+            "_id": 1,
+            "names": 1,
+            "external_ids": 1,
+            "external_urls": 1,
+            "relations": 1,
+            "types": 1,
+            "citations_count": 1,
+            "products_count": 1,
+            "relations_data": 1,
+            "addresses": {
+                "$map": {
+                    "input": "$addresses",
+                    "as": "addr",
+                    "in": {"country": "$$addr.country", "country_code": "$$addr.country_code"},
+                }
+            },
+        }
     }
     affiliations, total_results = affiliation_repository.search_affiliations(
         affiliation_type, query_params, pipeline_params

--- a/quyca/domain/services/affiliation_service.py
+++ b/quyca/domain/services/affiliation_service.py
@@ -48,24 +48,19 @@ def get_related_affiliations_by_affiliation(affiliation_id: str, affiliation_typ
 
 def search_affiliations(affiliation_type: str, query_params: QueryParams) -> dict:
     pipeline_params = {
-        "project": {
-            "_id": 1,
-            "names": 1,
-            "external_ids": 1,
-            "external_urls": 1,
-            "relations": 1,
-            "types": 1,
-            "citations_count": 1,
-            "products_count": 1,
-            "relations_data": 1,
-            "addresses": {
-                "$map": {
-                    "input": "$addresses",
-                    "as": "addr",
-                    "in": {"country": "$$addr.country", "country_code": "$$addr.country_code"},
-                }
-            },
-        }
+        "project": [
+            "_id",
+            "names",
+            "addresses.country_code",
+            "addresses.country",
+            "external_ids",
+            "external_urls",
+            "relations",
+            "types",
+            "citations_count",
+            "products_count",
+            "relations_data",
+        ]
     }
     affiliations, total_results = affiliation_repository.search_affiliations(
         affiliation_type, query_params, pipeline_params

--- a/quyca/domain/services/api_expert_service.py
+++ b/quyca/domain/services/api_expert_service.py
@@ -1,11 +1,8 @@
-from datetime import datetime
 from typing import Generator
 
-from quyca.domain.models.base_model import QueryParams, Affiliation, Author, ExternalId
-from quyca.domain.models.work_model import Work, Source
+from quyca.domain.models.base_model import QueryParams
 from quyca.infrastructure.repositories import api_expert_repository
 from quyca.domain.parsers import work_parser
-from quyca.domain.services import source_service
 
 
 def get_works_by_person(person_id: str, query_params: QueryParams) -> dict:
@@ -27,70 +24,6 @@ def search_works(query_params: QueryParams) -> dict:
 
 
 def process_works(works: Generator) -> list:
-    works_list = []
-    for work in works:
-        set_authors_data(work)
-        set_authors_affiliations_data(work)
-        set_source_data(work)
-        works_list.append(work)
+    works_list = list(works)
     data = work_parser.parse_api_expert(works_list)
     return data
-
-
-def set_authors_data(work: Work) -> None:
-    for author in work.authors:
-        author_data = Author()
-        if work.authors_data:
-            author_data = next(filter(lambda x: x.id == author.id, work.authors_data), Author())
-        author.external_ids = author_data.external_ids
-        author.ranking = author_data.ranking
-        author.last_names = author_data.last_names
-        author.first_names = author_data.first_names
-        author.sex = author_data.sex
-        author.affiliations = author_data.affiliations
-        if author_data.birthplace:
-            author.birth_country = author_data.birthplace.country
-        if author_data.birthdate and author_data.birthdate != -1 and author_data.birthdate != "":
-            birthdate = datetime.fromtimestamp(author_data.birthdate)
-            today = datetime.today()
-            age = today.year - birthdate.year
-            if (today.month, today.day) < (birthdate.month, birthdate.day):
-                age -= 1
-            author.age = age
-    work.authors_data = None
-
-
-def set_authors_affiliations_data(work: Work) -> None:
-    for author in work.authors:
-        author.countries = []
-        for affiliation in author.affiliations:
-            affiliation_data = Affiliation()
-            if work.affiliations_data:
-                affiliation_data = next(filter(lambda x: x.id == affiliation.id, work.affiliations_data), Affiliation())
-            if affiliation_data.external_ids:
-                affiliation.ror = next(
-                    filter(lambda x: x.source == "ror", affiliation_data.external_ids), ExternalId()
-                ).id
-            if affiliation_data.addresses and (address := affiliation_data.addresses[0]):
-                affiliation.geo.country = address.country
-                affiliation.geo.country_code = address.country_code
-                affiliation.geo.region = address.state
-                affiliation.geo.city = address.city
-                affiliation.geo.latitude = address.lat
-                affiliation.geo.longitude = address.lng
-                author.countries.append(affiliation.geo.country)
-        author.countries = list(set(author.countries))
-    work.affiliations_data = None
-
-
-def set_source_data(work: Work) -> None:
-    source_data = next(filter(lambda x: x.id == work.source.id, work.source_data), Source())
-    work.source.types = source_data.types
-    if source_data.external_ids:
-        work.source.issn_l = next(filter(lambda x: x.source == "issn_l", source_data.external_ids), ExternalId()).id
-    if source_data.updated:
-        work.source.is_in_doaj = (
-            True if next(filter(lambda x: x.source == "doaj", source_data.updated), None) else False
-        )
-    source_service.update_work_source(work)
-    work.source_data = None

--- a/quyca/domain/services/info_service.py
+++ b/quyca/domain/services/info_service.py
@@ -13,6 +13,8 @@ def get_info() -> dict:
         "total_groups": info_repository.get_entity_count("affiliations", "group"),
         "total_patents": info_repository.get_entity_count("patents"),
         "total_projects": info_repository.get_entity_count("projects"),
-        "total_other_products": info_repository.get_entity_count("works_misc"),
         "total_authors": info_repository.get_entity_count("person"),
+        "total_news": info_repository.get_news_count(),
+        "total_open_access": info_repository.get_open_access_count(),
+        "total_sources": info_repository.get_entity_count("sources"),
     }

--- a/quyca/domain/services/person_plot_service.py
+++ b/quyca/domain/services/person_plot_service.py
@@ -33,7 +33,14 @@ def plot_annual_citation_count(person_id: str, query_params: QueryParams) -> dic
 
 
 def plot_annual_apc_expenses(person_id: str, query_params: QueryParams) -> dict:
-    pipeline_params = {"source_project": ["apc"], "work_project": ["source", "year_published"]}
+    pipeline_params = {
+        "work_project": [
+            "source.id",
+            "source.name",
+            "year_published",
+            "source.apc",
+        ]
+    }
     works = work_repository.get_works_with_source_by_person(person_id, query_params, pipeline_params)
     return bar_parser.parse_annual_apc_expenses(works)
 
@@ -49,11 +56,17 @@ def plot_annual_articles_open_access(person_id: str, query_params: QueryParams) 
 
 def plot_annual_articles_by_top_publishers(person_id: str, query_params: QueryParams) -> dict:
     pipeline_params = {
-        "source_project": ["publisher", "apc"],
-        "work_project": ["source", "year_published", "types"],
+        "work_project": [
+            "source.id",
+            "source.name",
+            "source.publisher.name",
+            "year_published",
+            "types",
+            "source.apc",
+        ],
         "match": {
             "types.type": {"$in": articles_types_list},
-            "source.publisher.name": {"$ne": float("nan")},
+            "source.publisher.name": {"$ne": None},
         },
     }
     works = work_repository.get_works_with_source_by_person(person_id, query_params, pipeline_params)
@@ -67,8 +80,7 @@ def plot_most_used_title_words(person_id: str, query_params: QueryParams) -> dic
 
 def plot_articles_by_publisher(person_id: str, query_params: QueryParams) -> dict:
     pipeline_params = {
-        "source_project": ["publisher"],
-        "work_project": ["source"],
+        "work_project": ["source.id", "source.name", "source.publisher.name"],
         "match": {"types.type": {"$in": articles_types_list}},
     }
     works = work_repository.get_works_with_source_by_person(person_id, query_params, pipeline_params)
@@ -109,8 +121,12 @@ def plot_articles_by_scienti_category(person_id: str, query_params: QueryParams)
 
 def plot_articles_by_scimago_quartile(person_id: str, query_params: QueryParams) -> dict:
     pipeline_params = {
-        "source_project": ["ranking"],
-        "work_project": ["source", "date_published"],
+        "work_project": [
+            "source.id",
+            "source.name",
+            "date_published",
+            "source.ranking",
+        ],
         "match": {"types.type": {"$in": articles_types_list}},
     }
     works = work_repository.get_works_with_source_by_person(person_id, query_params, pipeline_params)
@@ -127,8 +143,7 @@ def plot_articles_by_publishing_institution(person_id: str, query_params: QueryP
             institution = affiliation_repository.get_affiliation_by_id(str(affiliation.id))
             break
     pipeline_params = {
-        "source_project": ["publisher"],
-        "work_project": ["source"],
+        "work_project": ["source.id", "source.name", "source.publisher.name"],
         "match": {"types.type": {"$in": articles_types_list}},
     }
     works = work_repository.get_works_with_source_by_person(person_id, query_params, pipeline_params)

--- a/quyca/infrastructure/repositories/affiliation_repository.py
+++ b/quyca/infrastructure/repositories/affiliation_repository.py
@@ -14,15 +14,6 @@ from domain.exceptions.not_entity_exception import NotEntityException
 def get_affiliation_by_id(affiliation_id: str) -> Affiliation:
     pipeline = [
         {"$match": {"_id": affiliation_id}},
-        {
-            "$lookup": {
-                "from": "affiliations",
-                "localField": "relations.id",
-                "foreignField": "_id",
-                "as": "relations_data",
-                "pipeline": [{"$project": {"id": "$_id", "external_urls": 1}}],
-            }
-        },
     ]
     try:
         affiliation_data = database["affiliations"].aggregate(pipeline).next()
@@ -70,26 +61,13 @@ def get_groups_by_faculty_or_department(affiliation_id: str) -> Generator:
             }
         },
         {"$unwind": "$affiliations"},
-        {"$match": {"affiliations.types.type": "group"}},
         {
-            "$lookup": {
-                "from": "affiliations",
-                "localField": "affiliations.id",
-                "foreignField": "_id",
-                "as": "group",
-                "pipeline": [
-                    {
-                        "$match": {
-                            "relations.id": institution_id,
-                            "types.type": "group",
-                        },
-                    },
-                    {"$project": {"_id": 1, "names": 1}},
-                ],
+            "$match": {
+                "affiliations.types.type": "group",
+                "affiliations.relations.id": institution_id,
             }
         },
-        {"$unwind": "$group"},
-        {"$group": {"_id": "$group._id", "names": {"$first": "$group.names"}}},
+        {"$group": {"_id": "$affiliations.id", "names": {"$push": "$affiliations.name"}}},
     ]
     groups = database["person"].aggregate(pipeline)
     return affiliation_generator.get(groups)

--- a/quyca/infrastructure/repositories/affiliation_repository.py
+++ b/quyca/infrastructure/repositories/affiliation_repository.py
@@ -110,21 +110,20 @@ def search_affiliations(
         },
         {
             "$lookup": {
-                "from": "affiliations",  # type: ignore
-                "localField": "relations.id",  # type: ignore
-                "foreignField": "_id",  # type: ignore
-                "as": "relations_data",  # type: ignore
-                "pipeline": [{"$project": {"id": "$_id", "external_urls": 1}}],  # type: ignore
+                "from": "affiliations",
+                "localField": "relations.id",
+                "foreignField": "_id",
+                "as": "relations_data",
+                "pipeline": [{"$project": {"id": "$_id", "external_urls": 1}}],
             }
         },
-        {"$project": {"works": 0}},  # type: ignore
     ]
     base_repository.set_search_end_stages(pipeline, query_params, pipeline_params)
     affiliations = database["affiliations"].aggregate(pipeline)
     count_pipeline = [{"$match": {"$text": {"$search": query_params.keywords}}}] if query_params.keywords else []
     count_pipeline += [
         {"$match": {"types.type": {"$in": types}}},
-        {"$count": "total_results"},  # type: ignore
+        {"$count": "total_results"},
     ]
     total_results = next(database["affiliations"].aggregate(count_pipeline), {"total_results": 0})["total_results"]
     return affiliation_generator.get(affiliations), total_results

--- a/quyca/infrastructure/repositories/api_expert_repository.py
+++ b/quyca/infrastructure/repositories/api_expert_repository.py
@@ -42,6 +42,10 @@ def get_works_for_api_expert(pipeline: list, pipeline_params: dict, query_params
     base_repository.set_match(pipeline, pipeline_params.get("match"))
     if sort := query_params.sort:
         base_repository.set_sort(sort, pipeline)
+
+    if query_params.page and query_params.limit:
+        base_repository.set_pagination(pipeline, query_params)
+
     pipeline += [
         {
             "$lookup": {
@@ -85,7 +89,7 @@ def get_works_for_api_expert(pipeline: list, pipeline_params: dict, query_params
                             "external_ids": 1,
                             "updated": 1,
                         }
-                    },
+                    }
                 ],
             }
         },
@@ -99,8 +103,8 @@ def get_works_for_api_expert(pipeline: list, pipeline_params: dict, query_params
             },
         },
     ]
+
     work_repository.set_product_filters(pipeline, query_params)
     base_repository.set_project(pipeline, pipeline_params.get("project"))
-    base_repository.set_pagination(pipeline, query_params)
     cursor = database["works"].aggregate(pipeline)
     return work_generator.get(cursor)

--- a/quyca/infrastructure/repositories/api_expert_repository.py
+++ b/quyca/infrastructure/repositories/api_expert_repository.py
@@ -1,6 +1,5 @@
 from typing import Generator
 
-
 from quyca.infrastructure.generators import work_generator
 from quyca.domain.models.base_model import QueryParams
 from quyca.infrastructure.repositories import base_repository, work_repository
@@ -48,58 +47,40 @@ def get_works_for_api_expert(pipeline: list, pipeline_params: dict, query_params
 
     pipeline += [
         {
-            "$lookup": {
-                "from": "person",
-                "localField": "authors.id",
-                "foreignField": "_id",
-                "as": "authors_data",
-                "pipeline": [
-                    {
-                        "$project": {
-                            "id": "$_id",
-                            "sex": 1,
-                            "birthplace.country": 1,
-                            "birthdate": 1,
-                            "first_names": 1,
-                            "last_names": 1,
-                            "affiliations.id": 1,
-                            "affiliations.start_date": 1,
-                            "affiliations.end_date": 1,
-                            "affiliations.name": 1,
-                            "affiliations.types": 1,
-                            "ranking": 1,
-                            "external_ids": 1,
+            "$project": {
+                "_id": 1,
+                "titles": 1,
+                "year_published": 1,
+                "doi": 1,
+                "authors": {
+                    "id": 1,
+                    "full_name": 1,
+                    "sex": 1,
+                    "first_names": 1,
+                    "last_names": 1,
+                    "external_ids": 1,
+                    "ranking": 1,
+                    "affiliations": {
+                        "$map": {
+                            "input": "$authors.affiliations",
+                            "as": "aff",
+                            "in": {
+                                "id": "$$aff.id",
+                                "name": "$$aff.name",
+                                "types": "$$aff.types",
+                                "addresses": "$$aff.addresses",
+                                "external_ids": "$$aff.external_ids",
+                            },
                         }
                     },
-                ],
-            }
-        },
-        {
-            "$lookup": {
-                "from": "sources",
-                "localField": "source.id",
-                "foreignField": "_id",
-                "as": "source_data",
-                "pipeline": [
-                    {
-                        "$project": {
-                            "names": 1,
-                            "id": "$_id",
-                            "types": 1,
-                            "external_ids": 1,
-                            "updated": 1,
-                        }
-                    }
-                ],
-            }
-        },
-        {
-            "$lookup": {
-                "from": "affiliations",
-                "localField": "authors.affiliations.id",
-                "foreignField": "_id",
-                "as": "affiliations_data",
-                "pipeline": [{"$project": {"id": "$_id", "addresses": 1, "external_ids": 1}}],
+                },
+                "source": {
+                    "id": 1,
+                    "name": 1,
+                    "types": 1,
+                    "external_ids": 1,
+                    "updated": 1,
+                },
             },
         },
     ]

--- a/quyca/infrastructure/repositories/base_repository.py
+++ b/quyca/infrastructure/repositories/base_repository.py
@@ -34,40 +34,6 @@ def set_sort(sort: str | None, pipeline: list) -> None:
     sort_field, direction_str = sort.split("_")
     direction = -1 if direction_str == "desc" else 1
     if sort_field == "citations":
-        pipeline += [
-            {
-                "$addFields": {
-                    "openalex_citations_count": {
-                        "$ifNull": [
-                            {
-                                "$arrayElemAt": [
-                                    {
-                                        "$map": {
-                                            "input": {
-                                                "$filter": {
-                                                    "input": "$citations_count",
-                                                    "as": "citation",
-                                                    "cond": {
-                                                        "$eq": [
-                                                            "$$citation.source",
-                                                            "openalex",
-                                                        ]
-                                                    },
-                                                }
-                                            },
-                                            "as": "filtered",
-                                            "in": "$$filtered.count",
-                                        }
-                                    },
-                                    0,
-                                ]
-                            },
-                            0,
-                        ]
-                    }
-                }
-            }
-        ]
         sort_field = "openalex_citations_count"
     elif sort_field == "alphabetical":
         pipeline += [

--- a/quyca/infrastructure/repositories/base_repository.py
+++ b/quyca/infrastructure/repositories/base_repository.py
@@ -22,10 +22,13 @@ def set_match(pipeline: list, match: dict | None) -> None:
     pipeline += [{"$match": match}]
 
 
-def set_project(pipeline: list, project: list | None) -> None:
+def set_project(pipeline: list, project: list | dict | None) -> None:
     if not project:
         return
-    pipeline += [{"$project": {"_id": 1, **{p: 1 for p in project}}}]
+    if isinstance(project, dict):
+        pipeline.append({"$project": project})
+    elif isinstance(project, list):
+        pipeline.append({"$project": {"_id": 1, **{p: 1 for p in project}}})
 
 
 def set_sort(sort: str | None, pipeline: list) -> None:

--- a/quyca/infrastructure/repositories/base_repository.py
+++ b/quyca/infrastructure/repositories/base_repository.py
@@ -25,10 +25,8 @@ def set_match(pipeline: list, match: dict | None) -> None:
 def set_project(pipeline: list, project: list | dict | None) -> None:
     if not project:
         return
-    if isinstance(project, dict):
-        pipeline.append({"$project": project})
-    elif isinstance(project, list):
-        pipeline.append({"$project": {"_id": 1, **{p: 1 for p in project}}})
+    
+    pipeline.append({"$project": {"_id": 1, **{p: 1 for p in project}}})
 
 
 def set_sort(sort: str | None, pipeline: list) -> None:

--- a/quyca/infrastructure/repositories/base_repository.py
+++ b/quyca/infrastructure/repositories/base_repository.py
@@ -35,7 +35,7 @@ def set_sort(sort: str | None, pipeline: list) -> None:
     sort_field, direction_str = sort.split("_")
     direction = -1 if direction_str == "desc" else 1
     if sort_field == "citations":
-        sort_field = "openalex_citations_count"
+        sort_field = "citations_count_openalex"
     elif sort_field == "alphabetical":
         pipeline += [
             {

--- a/quyca/infrastructure/repositories/base_repository.py
+++ b/quyca/infrastructure/repositories/base_repository.py
@@ -25,7 +25,7 @@ def set_match(pipeline: list, match: dict | None) -> None:
 def set_project(pipeline: list, project: list | dict | None) -> None:
     if not project:
         return
-    
+
     pipeline.append({"$project": {"_id": 1, **{p: 1 for p in project}}})
 
 

--- a/quyca/infrastructure/repositories/csv_repository.py
+++ b/quyca/infrastructure/repositories/csv_repository.py
@@ -14,49 +14,25 @@ def get_works_csv_by_person(person_id: str, query_params: QueryParams) -> Genera
     work_repository.set_product_filters(pipeline, query_params)
     pipeline += [
         {
-            "$lookup": {
-                "from": "affiliations",  # type: ignore
-                "localField": "authors.affiliations.id",  # type: ignore
-                "foreignField": "_id",  # type: ignore
-                "as": "affiliations_data",  # type: ignore
-                "pipeline": [{"$project": {"id": "$_id", "addresses.country": 1, "ranking": 1}}],  # type: ignore
-            }
-        },
-        {
-            "$lookup": {
-                "from": "sources",  # type: ignore
-                "localField": "source.id",  # type: ignore
-                "foreignField": "_id",  # type: ignore
-                "as": "source_data",  # type: ignore
-                "pipeline": [  # type: ignore
-                    {
-                        "$project": {
-                            "external_urls": 1,
-                            "ranking": 1,
-                            "publisher": 1,
-                            "apc": 1,
-                        }
-                    }
-                ],
-            }
-        },
-        {
             "$project": {
-                "external_ids": 1,  # type: ignore
-                "authors": 1,  # type: ignore
-                "affiliations_data": 1,  # type: ignore
-                "bibliographic_info": 1,  # type: ignore
-                "citations_count": 1,  # type: ignore
-                "open_access": 1,  # type: ignore
-                "subjects": 1,  # type: ignore
-                "titles": 1,  # type: ignore
-                "types": 1,  # type: ignore
-                "source": 1,  # type: ignore
-                "source_data": 1,  # type: ignore
-                "year_published": 1,  # type: ignore
-                "ranking": 1,  # type: ignore
-                "abstract": 1,  # type: ignore
-                "primary_topic": 1,  # type: ignore
+                "external_ids": 1,
+                "authors": 1,
+                "bibliographic_info": 1,
+                "open_access": 1,
+                "citations_count": 1,
+                "subjects": 1,
+                "titles": 1,
+                "types": 1,
+                "source": 1,
+                "year_published": 1,
+                "ranking": 1,
+                "abstract": 1,
+                "primary_topic": 1,
+                "affiliations_data": {
+                    "id": "$authors.affiliations.id",
+                    "addresses": {"country": "$authors.affiliations.addresses.country"},
+                    "ranking": "$authors.affiliations.ranking",
+                },
             }
         },
     ]
@@ -71,49 +47,25 @@ def get_works_csv_by_affiliation(affiliation_id: str, query_params: QueryParams)
     work_repository.set_product_filters(pipeline, query_params)
     pipeline += [
         {
-            "$lookup": {
-                "from": "affiliations",  # type: ignore
-                "localField": "authors.affiliations.id",  # type: ignore
-                "foreignField": "_id",  # type: ignore
-                "as": "affiliations_data",  # type: ignore
-                "pipeline": [{"$project": {"id": "$_id", "addresses.country": 1, "ranking": 1}}],  # type: ignore
-            }
-        },
-        {
-            "$lookup": {
-                "from": "sources",  # type: ignore
-                "localField": "source.id",  # type: ignore
-                "foreignField": "_id",  # type: ignore
-                "as": "source_data",  # type: ignore
-                "pipeline": [  # type: ignore
-                    {
-                        "$project": {
-                            "external_urls": 1,
-                            "ranking": 1,
-                            "publisher": 1,
-                            "apc": 1,
-                        }
-                    }
-                ],
-            }
-        },
-        {
             "$project": {
-                "external_ids": 1,  # type: ignore
-                "authors": 1,  # type: ignore
-                "affiliations_data": 1,  # type: ignore
-                "bibliographic_info": 1,  # type: ignore
-                "open_access": 1,  # type: ignore
-                "citations_count": 1,  # type: ignore
-                "subjects": 1,  # type: ignore
-                "titles": 1,  # type: ignore
-                "types": 1,  # type: ignore
-                "source": 1,  # type: ignore
-                "source_data": 1,  # type: ignore
-                "year_published": 1,  # type: ignore
-                "ranking": 1,  # type: ignore
-                "abstract": 1,  # type: ignore
-                "primary_topic": 1,  # type: ignore
+                "external_ids": 1,
+                "authors": 1,
+                "bibliographic_info": 1,
+                "open_access": 1,
+                "citations_count": 1,
+                "subjects": 1,
+                "titles": 1,
+                "types": 1,
+                "source": 1,
+                "year_published": 1,
+                "ranking": 1,
+                "abstract": 1,
+                "primary_topic": 1,
+                "affiliations_data": {
+                    "id": "$authors.affiliations.id",
+                    "addresses": {"country": "$authors.affiliations.addresses.country"},
+                    "ranking": "$authors.affiliations.ranking",
+                },
             }
         },
     ]

--- a/quyca/infrastructure/repositories/info_repository.py
+++ b/quyca/infrastructure/repositories/info_repository.py
@@ -3,8 +3,8 @@ from quyca.infrastructure.mongo import database
 
 
 def get_last_db_update() -> int:
-    pipeline = [{"$group": {"_id": None, "max_time": {"$max": "$time"}}}]
-    return next(database["log"].aggregate(pipeline), {"max_time": 0}).get("max_time", 0)
+    doc = database["log"].find_one(sort=[("time", -1)], projection={"time": 1})
+    return doc["time"] if doc else 0
 
 
 def get_entity_count(entity: str, affiliation_type: str | None = None) -> int:
@@ -12,4 +12,10 @@ def get_entity_count(entity: str, affiliation_type: str | None = None) -> int:
         if affiliation_type == "institution":
             return database[entity].count_documents({"types.type": {"$in": institutions_list}})
         return database[entity].count_documents({"types.type": affiliation_type})
-    return database[entity].count_documents({})
+    return database[entity].estimated_document_count({})
+
+def get_open_access_count() -> int:
+    return database["works"].count_documents({"open_access.is_open_access": True})
+
+def get_news_count() -> int:
+    return database["news_urls_collection"].estimated_document_count({})

--- a/quyca/infrastructure/repositories/info_repository.py
+++ b/quyca/infrastructure/repositories/info_repository.py
@@ -14,8 +14,10 @@ def get_entity_count(entity: str, affiliation_type: str | None = None) -> int:
         return database[entity].count_documents({"types.type": affiliation_type})
     return database[entity].estimated_document_count({})
 
+
 def get_open_access_count() -> int:
     return database["works"].count_documents({"open_access.is_open_access": True})
+
 
 def get_news_count() -> int:
     return database["news_urls_collection"].estimated_document_count({})

--- a/quyca/infrastructure/repositories/plot_repository.py
+++ b/quyca/infrastructure/repositories/plot_repository.py
@@ -14,15 +14,6 @@ def get_affiliations_scienti_works_count_by_institution(
 ) -> CommandCursor:
     pipeline = [
         {"$match": {"relations.id": institution_id, "types.type": relation_type}},
-        {
-            "$lookup": {
-                "from": "works",
-                "localField": "_id",
-                "foreignField": "authors.affiliations.id",
-                "as": "works",
-                "pipeline": [{"$project": {"types": 1}}],
-            }
-        },
         {"$unwind": "$works"},
         {"$unwind": "$works.types"},
         {"$match": {"works.types.source": "scienti", "works.types.level": 2}},
@@ -32,7 +23,7 @@ def get_affiliations_scienti_works_count_by_institution(
         {
             "$group": {
                 "_id": {"id": "$_id", "type": "$works.types.type", "name": "$names.name"},
-                "works_count": {"$sum": 1},
+                "works_count": {"$sum": "$works.types.count"},
             }
         },
         {"$project": {"_id": 0, "type": "$_id.type", "works_count": 1, "name": {"$first": "$_id.name"}}},
@@ -68,20 +59,10 @@ def get_groups_scienti_works_count_by_faculty_or_department(
                 "types.type": "group",
             }
         },
-        {
-            "$lookup": {
-                "from": "works",
-                "localField": "_id",
-                "foreignField": "authors.affiliations.id",
-                "as": "works",
-                "pipeline": [{"$project": {"types": 1, "authors": 1}}],
-            }
-        },
         {"$unwind": "$works"},
         {"$unwind": "$works.types"},
         {
             "$match": {
-                "works.authors.affiliations.id": affiliation_id,
                 "works.types.source": "scienti",
                 "works.types.level": 2,
             }
@@ -92,12 +73,18 @@ def get_groups_scienti_works_count_by_faculty_or_department(
         {
             "$group": {
                 "_id": {"id": "$_id", "type": "$works.types.type", "name": "$names.name"},
-                "works_count": {"$sum": 1},
+                "works_count": {"$sum": "$works.types.count"},
             }
         },
-        {"$project": {"_id": 0, "type": "$_id.type", "works_count": 1, "name": {"$first": "$_id.name"}}},
+        {
+            "$project": {
+                "_id": 0,
+                "type": "$_id.type",
+                "works_count": 1,
+                "name": {"$first": "$_id.name"},
+            }
+        },
     ]
-
     return database["affiliations"].aggregate(pipeline)
 
 
@@ -114,47 +101,16 @@ def get_departments_citations_count_by_faculty(affiliation_id: str) -> CommandCu
 
 
 def get_groups_citations_count_by_faculty_or_department(affiliation_id: str) -> CommandCursor:
-    institution_id = (
-        database["affiliations"]
-        .aggregate(
-            [
-                {"$match": {"_id": affiliation_id}},
-                {"$unwind": "$relations"},
-                {"$match": {"relations.types.type": "Education"}},
-            ]
-        )
-        .next()
-        .get("relations", {})
-        .get("id", None)
-    )
     groups_ids = [group.id for group in affiliation_repository.get_groups_by_faculty_or_department(affiliation_id)]
     pipeline = [
-        {"$unwind": "$groups"},
         {"$match": {"groups.id": {"$in": groups_ids}}},
-        {
-            "$lookup": {
-                "from": "affiliations",
-                "localField": "groups.id",
-                "foreignField": "_id",
-                "as": "group",
-                "pipeline": [
-                    {
-                        "$match": {
-                            "relations.id": institution_id,
-                            "types.type": "group",
-                        },
-                    },
-                    {"$project": {"_id": 1, "name": {"$first": "$names.name"}, "citations_count": 1}},
-                ],
-            }
-        },
-        {"$unwind": "$group"},
-        {"$replaceRoot": {"newRoot": "$group"}},
+        {"$project": {"groups": 1}},
+        {"$unwind": "$groups"},
         {
             "$group": {
-                "_id": "$_id",
-                "name": {"$first": "$name"},
-                "citations_count": {"$first": "$citations_count"},
+                "_id": "$groups.id",
+                "name": {"$first": "$groups.name"},
+                "citations_count": {"$first": "$groups.citations_count"},
             }
         },
     ]
@@ -166,31 +122,11 @@ def get_affiliations_apc_expenses_by_institution(
 ) -> CommandCursor:
     pipeline = [
         {"$match": {"relations.id": institution_id, "types.type": relation_type}},
-        {
-            "$lookup": {
-                "from": "works",
-                "localField": "_id",
-                "foreignField": "authors.affiliations.id",
-                "as": "works",
-                "pipeline": [{"$project": {"source": 1}}],
-            }
-        },
         {"$unwind": "$works"},
+        {"$unwind": "$works.source"},
     ]
     set_plot_product_filters(pipeline, query_params)
-    pipeline += [
-        {
-            "$lookup": {
-                "from": "sources",
-                "localField": "works.source.id",
-                "foreignField": "_id",
-                "as": "source",
-                "pipeline": [{"$project": {"apc": 1}}],
-            }
-        },
-        {"$unwind": "$source"},
-        {"$project": {"_id": 0, "source": 1, "names": 1}},
-    ]
+    pipeline += [{"$project": {"names": 1, "apc": "$works.source"}}]
     return database["affiliations"].aggregate(pipeline)
 
 
@@ -219,34 +155,11 @@ def get_groups_apc_expenses_by_faculty_or_department(affiliation_id: str, query_
                 "types.type": "group",
             }
         },
-        {
-            "$lookup": {
-                "from": "works",
-                "localField": "_id",
-                "foreignField": "authors.affiliations.id",
-                "as": "works",
-                "pipeline": [
-                    {"$match": {"authors.affiliations.id": affiliation_id}},
-                    {"$project": {"source": 1, "authors": 1}},
-                ],
-            }
-        },
         {"$unwind": "$works"},
+        {"$unwind": "$works.source"},
     ]
     set_plot_product_filters(pipeline, query_params)
-    pipeline += [
-        {
-            "$lookup": {
-                "from": "sources",
-                "localField": "works.source.id",
-                "foreignField": "_id",
-                "as": "source",
-                "pipeline": [{"$project": {"apc": 1}}],
-            }
-        },
-        {"$unwind": "$source"},
-        {"$project": {"_id": 0, "source": 1, "names": 1}},
-    ]
+    pipeline += [{"$project": {"names": 1, "apc": "$works.source"}}]
     return database["affiliations"].aggregate(pipeline)
 
 
@@ -255,53 +168,17 @@ def get_affiliations_works_citations_count_by_institution(
 ) -> CommandCursor:
     pipeline = [
         {"$match": {"relations.id": institution_id, "types.type": relation_type}},
-        {
-            "$lookup": {
-                "from": "works",
-                "localField": "_id",
-                "foreignField": "authors.affiliations.id",
-                "as": "works",
-                "pipeline": [
-                    {
-                        "$addFields": {
-                            "scholar_citations_count": {
-                                "$ifNull": [
-                                    {
-                                        "$arrayElemAt": [
-                                            {
-                                                "$map": {
-                                                    "input": {
-                                                        "$filter": {
-                                                            "input": "$citations_count",
-                                                            "as": "citation",
-                                                            "cond": {
-                                                                "$eq": [
-                                                                    "$$citation.source",
-                                                                    "scholar",
-                                                                ]
-                                                            },
-                                                        }
-                                                    },
-                                                    "as": "filtered",
-                                                    "in": "$$filtered.count",
-                                                }
-                                            },
-                                            0,
-                                        ]
-                                    },
-                                    0,
-                                ]
-                            }
-                        }
-                    },
-                    {"$project": {"scholar_citations_count": 1}},
-                ],
-            }
-        },
+        {"$unwind": "$works"},
     ]
     set_plot_product_filters(pipeline, query_params)
     pipeline += [
-        {"$project": {"_id": 0, "works": 1, "name": {"$first": "$names.name"}}},
+        {
+            "$project": {
+                "_id": 0,
+                "scholar_distribution": "$works.scholar_distribution",
+                "name": {"$first": "$names.name"},
+            }
+        },
     ]
     return database["affiliations"].aggregate(pipeline)
 
@@ -333,54 +210,17 @@ def get_groups_works_citations_count_by_faculty_or_department(
                 "types.type": "group",
             }
         },
-        {
-            "$lookup": {
-                "from": "works",
-                "localField": "_id",
-                "foreignField": "authors.affiliations.id",
-                "as": "works",
-                "pipeline": [
-                    {"$match": {"authors.affiliations.id": affiliation_id}},
-                    {
-                        "$addFields": {
-                            "scholar_citations_count": {
-                                "$ifNull": [
-                                    {
-                                        "$arrayElemAt": [
-                                            {
-                                                "$map": {
-                                                    "input": {
-                                                        "$filter": {
-                                                            "input": "$citations_count",
-                                                            "as": "citation",
-                                                            "cond": {
-                                                                "$eq": [
-                                                                    "$$citation.source",
-                                                                    "scholar",
-                                                                ]
-                                                            },
-                                                        }
-                                                    },
-                                                    "as": "filtered",
-                                                    "in": "$$filtered.count",
-                                                }
-                                            },
-                                            0,
-                                        ]
-                                    },
-                                    0,
-                                ]
-                            }
-                        }
-                    },
-                    {"$project": {"scholar_citations_count": 1}},
-                ],
-            }
-        },
+        {"$unwind": "$works"},
     ]
     set_plot_product_filters(pipeline, query_params)
     pipeline += [
-        {"$project": {"_id": 0, "works": 1, "name": {"$first": "$names.name"}}},
+        {
+            "$project": {
+                "_id": 0,
+                "scholar_distribution": "$works.scholar_distribution",
+                "name": {"$first": "$names.name"},
+            }
+        }
     ]
     return database["affiliations"].aggregate(pipeline)
 

--- a/quyca/infrastructure/repositories/plot_repository.py
+++ b/quyca/infrastructure/repositories/plot_repository.py
@@ -619,27 +619,25 @@ def get_works_rankings_by_person(person_id: str, query_params: QueryParams) -> T
     work_repository.set_product_filters(pipeline, query_params)
     pipeline += [
         {
-            "$lookup": {
-                "from": "sources",  # type: ignore
-                "localField": "source.id",  # type: ignore
-                "foreignField": "_id",  # type: ignore
-                "as": "source_data",  # type: ignore
-                "pipeline": [  # type: ignore
-                    {"$project": {"_id": 1, "ranking": 1}},
-                ],
+            "$project": {
+                "_id": 1,
+                "source.id": 1,
+                "date_published": 1,
+                "source.ranking": 1,
             }
         },
-        {"$unwind": "$source_data"},  # type: ignore
-        {"$project": {"_id": 1, "source_data": 1, "date_published": 1}},  # type: ignore
     ]
     count_pipeline = [
         {"$match": {"authors.id": person_id}},
     ]
     work_repository.set_product_filters(count_pipeline, query_params)
+
     count_pipeline += [
-        {"$count": "total_results"},  # type: ignore
+        {"$count": "total_results"},
     ]
+
     total_results = next(database["works"].aggregate(count_pipeline), {"total_results": 0})["total_results"]
+
     works = database["works"].aggregate(pipeline)
     return work_generator.get(works), total_results
 

--- a/quyca/infrastructure/repositories/work_repository.py
+++ b/quyca/infrastructure/repositories/work_repository.py
@@ -46,23 +46,10 @@ def get_works_with_source_by_affiliation(
 ) -> Generator:
     if pipeline_params is None:
         pipeline_params = {}
-    source_project = pipeline_params.get("source_project", [])
     pipeline = [
         {"$match": {"authors.affiliations.id": affiliation_id}},
     ]
     set_product_filters(pipeline, query_params)
-    pipeline += [
-        {
-            "$lookup": {
-                "from": "sources",  # type: ignore
-                "localField": "source.id",  # type: ignore
-                "foreignField": "_id",  # type: ignore
-                "as": "source",  # type: ignore
-                "pipeline": [{"$project": {"_id": 1, **{p: 1 for p in source_project}}}],  # type: ignore
-            }
-        },
-        {"$unwind": "$source"},  # type: ignore
-    ]
     base_repository.set_match(pipeline, pipeline_params.get("match"))
     base_repository.set_project(pipeline, pipeline_params.get("work_project"))
     cursor = database["works"].aggregate(pipeline)
@@ -78,7 +65,7 @@ def get_works_count_by_affiliation(affiliation_id: str, query_params: QueryParam
         },
     ]
     set_product_filters(pipeline, query_params)
-    pipeline += [{"$count": "total"}]  # type: ignore
+    pipeline += [{"$count": "total"}]
     return next(database["works"].aggregate(pipeline), {"total": 0}).get("total", 0)
 
 
@@ -103,23 +90,10 @@ def get_works_with_source_by_person(
 ) -> Generator:
     if pipeline_params is None:
         pipeline_params = {}
-    source_project = pipeline_params.get("source_project", [])
     pipeline = [
         {"$match": {"authors.id": person_id}},
     ]
     set_product_filters(pipeline, query_params)
-    pipeline += [
-        {
-            "$lookup": {
-                "from": "sources",  # type: ignore
-                "localField": "source.id",  # type: ignore
-                "foreignField": "_id",  # type: ignore
-                "as": "source",  # type: ignore
-                "pipeline": [{"$project": {"_id": 1, **{p: 1 for p in source_project}}}],  # type: ignore
-            }
-        },
-        {"$unwind": "$source"},  # type: ignore
-    ]
     base_repository.set_match(pipeline, pipeline_params.get("match"))
     base_repository.set_project(pipeline, pipeline_params.get("work_project"))
     cursor = database["works"].aggregate(pipeline)
@@ -129,7 +103,7 @@ def get_works_with_source_by_person(
 def get_works_count_by_person(person_id: str, query_params: QueryParams) -> int:
     pipeline = [{"$match": {"authors.id": person_id}}]
     set_product_filters(pipeline, query_params)
-    pipeline += [{"$count": "total"}]  # type: ignore
+    pipeline += [{"$count": "total"}]
     return next(database["works"].aggregate(pipeline), {"total": 0}).get("total", 0)
 
 
@@ -141,7 +115,7 @@ def search_works(query_params: QueryParams, pipeline_params: dict | None = None)
     count_pipeline = [{"$match": {"$text": {"$search": query_params.keywords}}}] if query_params.keywords else []
     set_product_filters(count_pipeline, query_params)
     count_pipeline += [
-        {"$count": "total_results"},  # type: ignore
+        {"$count": "total_results"},
     ]
     total_results = next(database["works"].aggregate(count_pipeline), {"total_results": 0}).get("total_results", 0)
     return work_generator.get(works), total_results
@@ -269,7 +243,7 @@ def set_product_type_filters(pipeline: list, type_filters: str | None) -> None:
             match_filters.append({"types": {"$elemMatch": {"source": params[0], "type": params[1]}}})
         elif len(params) == 3 and params[0] == "scienti":
             match_filters.append(
-                {"types": {"$elemMatch": {"source": params[0], "type": params[1], "code": {"$regex": "^" + params[2]}}}}  # type: ignore
+                {"types": {"$elemMatch": {"source": params[0], "type": params[1], "code": {"$regex": "^" + params[2]}}}}
             )
     pipeline += [{"$match": {"$or": match_filters}}]
 
@@ -291,9 +265,9 @@ def set_status_filters(pipeline: list, status: str | None) -> None:
         if single_status == "unknown":
             match_filters.append({"open_access.open_access_status": None})
         elif single_status == "open":
-            match_filters.append({"open_access.open_access_status": {"$nin": [None, "closed"]}})  # type: ignore
+            match_filters.append({"open_access.open_access_status": {"$nin": [None, "closed"]}})
         else:
-            match_filters.append({"open_access.open_access_status": single_status})  # type: ignore
+            match_filters.append({"open_access.open_access_status": single_status})
     pipeline += [{"$match": {"$or": match_filters}}]
 
 


### PR DESCRIPTION
#  What was done? 👁️
This pull request is about [impactu#593](https://github.com/colav/impactu/issues/593). Introduces several performance improvements for the works aggregation pipelines.

### Denormalized citation count 🔢 
- A new field `citations_count_openalex` is now stored directly in the works collection.  **[Using the omar's update](https://github.com/colav/impactu/issues/595)**
- The previous `$filter + $map` calculation in the aggregation pipeline has been **removed**.
- An index has been added to `citations_count_openalex` to improve query performance when sorting.

### Pagination reordering 📃 
- Pagination stages `($skip, $limit)` are now applied before the `$lookup` enrichments. This ensures that joins are performed only on the number of documents requested in the query param max, drastically reducing lookup overhead.

### Minor cleanups 🧹

- Removed leftover print statements.
- Removed # type: ignore comments from the aggregation pipeline definitions.

## Proofs
This image is before the optimization. We can see that the request does not resolve in 30seconds or less
<img width="1363" height="354" alt="image_2025-09-09_09-56-49" src="https://github.com/user-attachments/assets/55fb565d-dc1e-47d7-a145-23fa1f180884" />

This image is after the optimization. We can see a big time difference
<img width="981" height="130" alt="Sin query_params" src="https://github.com/user-attachments/assets/ade010ab-49d7-402b-a65b-59d08ddefcc4" />

Also if we use de query params like **`max` and `page`** we see that is the best way to improve the performance of API EXPERT
<img width="1114" height="125" alt="Con query_params" src="https://github.com/user-attachments/assets/e43d8007-2cd7-4596-a247-175a18eed88f" />
