### PR TITLE
Fix affiliation logo and empty affiliations handling

### DIFF
--- a/quyca/domain/services/affiliation_service.py
+++ b/quyca/domain/services/affiliation_service.py
@@ -88,9 +88,6 @@ def set_relation_external_urls(affiliation: Affiliation) -> None:
 
 
 def set_upper_affiliations_and_logo(affiliation: Affiliation, affiliation_type: str) -> None:
-    if not affiliation.relations:
-        return
-
     if affiliation_type == "institution" and affiliation.external_urls:
         logo_url = next(
             (x.url for x in affiliation.external_urls if x.source == "logo"),
@@ -99,6 +96,10 @@ def set_upper_affiliations_and_logo(affiliation: Affiliation, affiliation_type: 
         affiliation.logo = str(logo_url)
 
     upper_affiliations = []
+    if not affiliation.relations:
+        affiliation.affiliations = []
+        return
+
     for relation in affiliation.relations:
         if not relation.types:
             continue


### PR DESCRIPTION
Logo not being set for institutions without relations

Previously, the method returned early when relations was empty, skipping the logic that assigns a logo from external_urls.

Now the logo is correctly set even if the affiliation has no relations.

affiliations being returned as null instead of []

When an affiliation had no relations, the method exited without initializing affiliations.

Now it explicitly sets affiliations = [], ensuring the API always returns an empty list instead of null.