### PR TITLE
Use primary_topic in plot_products_by_subject

### DIFF
--- a/quyca/domain/parsers/pie_parser.py
+++ b/quyca/domain/parsers/pie_parser.py
@@ -84,17 +84,13 @@ def parse_articles_by_publisher(works: Generator) -> list:
 
 @get_percentage
 def parse_products_by_subject(works: Generator) -> list:
-    data = chain.from_iterable(
-        map(
-            lambda x: [sub for subject in x.subjects for sub in subject.subjects if subject.source == "openalex"],
-            works,
-        )
-    )
-    results = Counter(subject.name for subject in data)
-    plot = []
-    for name, value in results.items():
-        plot.append({"name": name, "value": value})
-    return sorted(plot, key=lambda x: x.get("value"), reverse=True)
+    names = [
+        work.primary_topic.display_name for work in works if work.primary_topic and work.primary_topic.display_name
+    ]
+
+    results = Counter(names)
+    plot = [{"name": name, "value": value} for name, value in results.items()]
+    return sorted(plot, key=lambda x: x["value"], reverse=True)
 
 
 @get_percentage

--- a/quyca/domain/services/affiliation_plot_service.py
+++ b/quyca/domain/services/affiliation_plot_service.py
@@ -154,8 +154,8 @@ def plot_articles_by_publisher(affiliation_id: str, query_params: QueryParams) -
 
 def plot_products_by_subject(affiliation_id: str, query_params: QueryParams) -> dict:
     pipeline_params = {
-        "match": {"subjects": {"$ne": []}},
-        "project": ["subjects"],
+        "topic_project": ["primary_topic.display_name"],
+        "match": {"primary_topic.display_name": {"$exists": True, "$ne": None}},
     }
     works = work_repository.get_works_by_affiliation(affiliation_id, query_params, pipeline_params)
     return pie_parser.parse_products_by_subject(works)


### PR DESCRIPTION
This PR is about the [issue](https://github.com/colav/impactu/issues/614) 

- Updated `plot_products_by_subject` in `affiliation_plot_service.py` to use `primary_topic.display_name` instead of `subjects`.
- Added `parse_products_by_primary_topic` in `pie_parser.py` to count by `primary_topic.display_name`