### PR TITLE
Counts for sources and filters

### DIFF
--- a/quyca/domain/models/source_model.py
+++ b/quyca/domain/models/source_model.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 
 from quyca.domain.models.base_model import (
+    CitationsCount,
     Type,
     Updated,
     ExternalId,
@@ -40,8 +41,11 @@ class Source(BaseModel):
     id: PyObjectId = Field(alias="_id")
     abbreviations: list[str] | None = None
     addresses: list | None = None
+    affiliation_names: list[Name] | None = None
     apc: APC | None = None
+    citations_count: list[CitationsCount] | None = None
     copyright: Copyright | None = None
+    date_published: str | int | None = None
     external_ids: list[ExternalId] | None = None
     external_urls: list[ExternalUrl] | None = None
     keywords: list[str] | None = None
@@ -50,6 +54,7 @@ class Source(BaseModel):
     names: list[Name] | None = None
     open_access_start_year: int | None = None
     plagiarism_detection: bool | None = None
+    products_count: int | None = None
     publication_time_weeks: int | None = None
     publisher: Publisher | str | None = None
     ranking: list[Ranking] | None = None
@@ -60,9 +65,6 @@ class Source(BaseModel):
     types: list[Type] | None = None
     updated: list[Updated] | None = None
     waiver: Waiver | None = None
-
-    date_published: str | int | None = None
-    affiliation_names: list[Name] | None = None
 
     class Config:
         json_encoders = {ObjectId: str}

--- a/quyca/domain/models/work_model.py
+++ b/quyca/domain/models/work_model.py
@@ -90,7 +90,6 @@ class Work(BaseModel):
     authors: list[Author] = Field(default_factory=list)
     authors_csv: str | None = None
     bibliographic_info: BiblioGraphicInfo | None = None
-    citations: list | None = Field(default_factory=list)
     citations_by_year: list[CitationByYear] | None = None
     citations_count: list[CitationsCount] | str | None = None
     date_published: int | None = None

--- a/quyca/domain/parsers/source_parser.py
+++ b/quyca/domain/parsers/source_parser.py
@@ -32,6 +32,8 @@ def parse_search_result(sources: List) -> List:
         "plagiarism_detection",
         "open_access_start_year",
         "publication_time_weeks",
+        "products_count",
+        "citations_count",
         "apc",
         "copyright",
         "licenses",
@@ -40,4 +42,7 @@ def parse_search_result(sources: List) -> List:
         "review_process",
     ]
 
-    return [source.model_dump(include=source_fields) for source in sources]
+    return [
+        source.model_dump(include=source_fields, exclude={"citations_count": {"__all__": {"provenance"}}})
+        for source in sources
+    ]

--- a/quyca/domain/services/source_service.py
+++ b/quyca/domain/services/source_service.py
@@ -103,7 +103,8 @@ def get_sources_by_entity_pipeline_params() -> Dict:
             "external_urls",
             "subjects",
             "ranking",
-        ]
+        ],
+        "collection": "sources",
     }
 
     return pipeline_source_params

--- a/quyca/infrastructure/repositories/base_repository.py
+++ b/quyca/infrastructure/repositories/base_repository.py
@@ -49,16 +49,14 @@ def set_sort(sort: str | None, pipeline: list, collection: str | None = None) ->
                                                 "$filter": {
                                                     "input": "$citations_count",
                                                     "as": "cite",
-                                                    "cond": {"$eq": ["$$cite.source", "openalex"]}
+                                                    "cond": {"$eq": ["$$cite.source", "openalex"]},
                                                 }
                                             },
-                                            0
+                                            0,
                                         ]
                                     }
                                 },
-                                "in": {
-                                    "$ifNull": ["$$openalexCitation.count", 0]
-                                }
+                                "in": {"$ifNull": ["$$openalexCitation.count", 0]},
                             }
                         }
                     }
@@ -131,7 +129,7 @@ def set_sort(sort: str | None, pipeline: list, collection: str | None = None) ->
                 {"$unset": ["names_order", "first_name"]},
             ]
             sort_field = "sort_name"
-        else: 
+        else:
             pipeline += [
                 {
                     "$addFields": {


### PR DESCRIPTION
**This PR adds count aggregations for `filters` and `sources` collection to improve data stats and enable sorting.**

### Available Filters Counts 🔢
Added count field to the following filters in /app/search/works/filters endpoint:

- **Countries**: Product count by affiliation country
- **Subjects**: Product count by discipline/subject (grouped by source)
- **Product Types**: Product count by type (grouped by source)
- **Status**: Product count by open access status

### Sources Collection Counts  📃 

Products count: Aggregated total products per source from works collection
Citations count: Aggregated OpenAlex citations per source from works collection

>[!IMPORTANT]
> Those calculations was made using `post-calculations`, in the comment below I add the `aggregation pipelines` and indexes for source collection.

### Sorting Enhancements ⬇️ 
Implemented sorting for sources:

- `sort=citations_asc|desc:` Sort by OpenAlex citation count
- `sort=products_asc|desc:` Sort by product count
- `sort=alphabetical_asc|desc:` Sort by source name (prioritized by source)

### Data Model Updates 🧮 

Modified `CitationsCount` model parser to `exclude` provenance field
Ensured `citations_count` returns as array format: [{"source": "openalex", "count": X}]