### PR TITLE
Hot fixes for affiliations api_expert and csv generations

### DIFF
--- a/quyca/application/routes/api/affiliation_api_router.py
+++ b/quyca/application/routes/api/affiliation_api_router.py
@@ -219,7 +219,7 @@ affiliation_api_router = Blueprint("affiliation_api_router", __name__)
 
 
 @affiliation_api_router.route("/<affiliation_type>/<affiliation_id>/research/products", methods=["GET"])
-def get_works_by_affiliation_api_expert(affiliation_id: str, affiliation_type: str) -> Response | Tuple[Response, int]:
+def get_works_by_affiliation_api_expert(affiliation_type: str, affiliation_id: str) -> Response | Tuple[Response, int]:
     try:
         query_params = QueryParams(**request.args)
         data = api_expert_service.get_works_by_affiliation(affiliation_id, query_params, affiliation_type)

--- a/quyca/application/routes/app/affiliation_app_router.py
+++ b/quyca/application/routes/app/affiliation_app_router.py
@@ -75,7 +75,7 @@ def get_affiliation_affiliations(affiliation_type: str, affiliation_id: str) -> 
 
 
 @affiliation_app_router.route("/<affiliation_type>/<affiliation_id>/research/products", methods=["GET"])
-def get_affiliation_research_products(affiliation_id: str, affiliation_type: str) -> Response | Tuple[Response, int]:
+def get_affiliation_research_products(affiliation_type: str, affiliation_id: str) -> Response | Tuple[Response, int]:
     try:
         query_params = QueryParams(**request.args)
         if query_params.plot:
@@ -102,7 +102,7 @@ def get_affiliation_research_products(affiliation_id: str, affiliation_type: str
 
 @affiliation_app_router.route("/<affiliation_type>/<affiliation_id>/research/products/filters", methods=["GET"])
 def get_affiliation_research_products_filters(
-    affiliation_id: str, affiliation_type: str
+    affiliation_type: str, affiliation_id: str
 ) -> Response | Tuple[Response, int]:
     try:
         query_params = QueryParams(**request.args)
@@ -129,7 +129,7 @@ def get_affiliation_research_products_filters(
 def get_works_csv_by_affiliation(affiliation_type: str, affiliation_id: str) -> Response | Tuple[Response, int]:
     try:
         query_params = QueryParams(**request.args)
-        data = csv_service.get_works_csv_by_affiliation(affiliation_id, query_params, affiliation_type)
+        data = csv_service.get_works_csv_by_affiliation(affiliation_id, query_params)
         response = Response(data, content_type="text/csv")
         response.headers["Content-Disposition"] = "attachment; filename=affiliation.csv"
         return response

--- a/quyca/domain/models/work_model.py
+++ b/quyca/domain/models/work_model.py
@@ -90,13 +90,13 @@ class Work(BaseModel):
     authors: list[Author] = Field(default_factory=list)
     authors_csv: str | None = None
     bibliographic_info: BiblioGraphicInfo | None = None
-    citations: list | None = Field(default_factory=list)
     citations_by_year: list[CitationByYear] | None = None
     citations_count: list[CitationsCount] | str | None = None
     date_published: int | None = None
     external_ids: list[ExternalId] | None = None
     external_urls: list[ExternalUrl] | None = None
     groups: list[Group] | None = None
+    groups_csv: str | None = None
     keywords: list | None = None
     open_access: OpenAccess | None = Field(default_factory=OpenAccess)
     ranking: list[Ranking] | str | None = None

--- a/quyca/domain/services/csv_service.py
+++ b/quyca/domain/services/csv_service.py
@@ -1,8 +1,8 @@
 from datetime import datetime
-from typing import Generator
+from typing import Any, Generator
 
 from quyca.domain.models.base_model import QueryParams
-from quyca.domain.models.work_model import Work
+from quyca.domain.models.work_model import BiblioGraphicInfo, Work
 from quyca.infrastructure.repositories import csv_repository
 from quyca.domain.constants.institutions import institutions_list
 from quyca.domain.constants.openalex_types import openalex_types_dict
@@ -14,15 +14,75 @@ from quyca.domain.parsers import work_parser
 def get_works_csv_by_affiliation(affiliation_id: str, query_params: QueryParams, affiliation_type: str) -> str:
     if affiliation_type == "institution":
         affiliation_type = "education"
-    works = csv_repository.get_works_csv_by_affiliation(affiliation_id, query_params, affiliation_type)
+    pipeline_params = get_works_project_pipeline_params()
+    works = csv_repository.get_works_csv_by_affiliation(affiliation_id, query_params, affiliation_type, pipeline_params)
     data = get_csv_data(works)
     return work_parser.parse_csv(data)
 
 
 def get_works_csv_by_person(person_id: str, query_params: QueryParams) -> str:
-    works = csv_repository.get_works_csv_by_person(person_id, query_params)
+    pipeline_params = get_works_project_pipeline_params()
+    works = csv_repository.get_works_csv_by_person(person_id, query_params, pipeline_params)
     data = get_csv_data(works)
     return work_parser.parse_csv(data)
+
+
+def get_works_csv_by_source(source_id: str, query_params: QueryParams) -> str:
+    """
+    Orchestrate the complete CSV generation process for works from a specific source.
+
+    This is the main service function that coordinates the entire workflow:
+    1. Define which fields to retrieve from database (projection)
+    2. Query works from database with filters
+    3. Process and transform raw data for CSV format
+    4. Generate final CSV string
+
+    Args:
+        source_id: Unique identifier of the source (institution, journal, etc.)
+        query_params: Query parameters for filtering and pagination
+
+    Returns:
+        str: Complete CSV file content as string, ready for HTTP response
+    """
+    pipeline_params = get_works_project_pipeline_params()
+    works = csv_repository.get_works_csv_by_source(source_id, query_params, pipeline_params)
+    data = get_csv_data(works)
+    return work_parser.parse_csv(data)
+
+
+def get_works_project_pipeline_params() -> dict:
+    """
+    Define database projection parameters for CSV export.
+
+    Specifies which fields should be retrieved from the database to minimize
+    data transfer and improve query performance. Only fields needed for CSV
+    export are included.
+
+    Returns:
+        dict: Pipeline parameters with 'project' key containing list of field names
+
+    Note:
+        Adding new columns to CSV requires adding corresponding fields here
+    """
+    pipeline_params = {
+        "project": [
+            "external_ids",
+            "authors",
+            "bibliographic_info",
+            "open_access",
+            "citations_count",
+            "subjects",
+            "titles",
+            "types",
+            "source",
+            "groups",
+            "year_published",
+            "ranking",
+            "primary_topic",
+            "doi",
+        ]
+    }
+    return pipeline_params
 
 
 def get_csv_data(works: Generator) -> list:
@@ -132,7 +192,7 @@ def set_csv_citations_count(work: Work) -> None:
 
 
 def set_csv_bibliographic_info(work: Work) -> None:
-    biblio_info = work.bibliographic_info or {}
+    biblio_info: BiblioGraphicInfo | dict[str, Any] = work.bibliographic_info or {}
 
     work.bibtex = getattr(biblio_info, "bibtex", None)
     work.pages = getattr(biblio_info, "pages", None)
@@ -189,6 +249,6 @@ def set_csv_affiliations(work: Work) -> None:
     work.institutions = " | ".join(institutions) or None
     work.departments = " | ".join(departments) or None
     work.faculties = " | ".join(faculties) or None
-    work.groups = " | ".join(groups) or None
+    work.groups_csv = " | ".join(groups) or None
     work.groups_ranking = " | ".join(groups_ranking) or None
     work.countries = " | ".join(countries) or None

--- a/quyca/domain/services/csv_service.py
+++ b/quyca/domain/services/csv_service.py
@@ -11,11 +11,9 @@ from quyca.domain.services import work_service
 from quyca.domain.parsers import work_parser
 
 
-def get_works_csv_by_affiliation(affiliation_id: str, query_params: QueryParams, affiliation_type: str) -> str:
-    if affiliation_type == "institution":
-        affiliation_type = "education"
+def get_works_csv_by_affiliation(affiliation_id: str, query_params: QueryParams) -> str:
     pipeline_params = get_works_project_pipeline_params()
-    works = csv_repository.get_works_csv_by_affiliation(affiliation_id, query_params, affiliation_type, pipeline_params)
+    works = csv_repository.get_works_csv_by_affiliation(affiliation_id, query_params, pipeline_params)
     data = get_csv_data(works)
     return work_parser.parse_csv(data)
 

--- a/quyca/infrastructure/repositories/api_expert_repository.py
+++ b/quyca/infrastructure/repositories/api_expert_repository.py
@@ -39,6 +39,7 @@ def search_works_for_api_expert(query_params: QueryParams, pipeline_params: dict
 
 
 def get_works_for_api_expert(pipeline: list, pipeline_params: dict, query_params: QueryParams) -> Generator:
+    work_repository.set_product_filters(pipeline, query_params)
     base_repository.set_match(pipeline, pipeline_params.get("match"))
     if sort := query_params.sort:
         base_repository.set_sort(sort, pipeline)
@@ -46,7 +47,6 @@ def get_works_for_api_expert(pipeline: list, pipeline_params: dict, query_params
     if query_params.page and query_params.limit:
         base_repository.set_pagination(pipeline, query_params)
 
-    work_repository.set_product_filters(pipeline, query_params)
     pipeline += [
         {
             "$project": {

--- a/quyca/infrastructure/repositories/csv_repository.py
+++ b/quyca/infrastructure/repositories/csv_repository.py
@@ -20,10 +20,10 @@ def get_works_csv_by_person(person_id: str, query_params: QueryParams, pipeline_
 
 
 def get_works_csv_by_affiliation(
-    affiliation_id: str, query_params: QueryParams, affiliation_type: str, pipeline_params: dict
+    affiliation_id: str, query_params: QueryParams, pipeline_params: dict
 ) -> Generator:
     pipeline: List[Dict[str, Any]] = [
-        {"$match": {"authors.affiliations.id": affiliation_id, "authors.affiliations.types.type": affiliation_type}},
+        {"$match": {"authors.affiliations.id": affiliation_id}},
     ]
     base_repository.set_project(pipeline, pipeline_params.get("project"))
     work_repository.set_product_filters(pipeline, query_params)

--- a/quyca/infrastructure/repositories/csv_repository.py
+++ b/quyca/infrastructure/repositories/csv_repository.py
@@ -19,9 +19,7 @@ def get_works_csv_by_person(person_id: str, query_params: QueryParams, pipeline_
     return work_generator.get(cursor)
 
 
-def get_works_csv_by_affiliation(
-    affiliation_id: str, query_params: QueryParams, pipeline_params: dict
-) -> Generator:
+def get_works_csv_by_affiliation(affiliation_id: str, query_params: QueryParams, pipeline_params: dict) -> Generator:
     pipeline: List[Dict[str, Any]] = [
         {"$match": {"authors.affiliations.id": affiliation_id}},
     ]

--- a/quyca/infrastructure/repositories/csv_repository.py
+++ b/quyca/infrastructure/repositories/csv_repository.py
@@ -1,65 +1,62 @@
-from typing import Generator
+from typing import Any, Dict, Generator, List
+
+from bson import ObjectId
 
 
 from quyca.domain.models.base_model import QueryParams
 from quyca.infrastructure.generators import work_generator
 from quyca.infrastructure.mongo import database
-from quyca.infrastructure.repositories import work_repository
+from quyca.infrastructure.repositories import base_repository, work_repository
 
 
-def get_works_csv_by_person(person_id: str, query_params: QueryParams) -> Generator:
-    pipeline = [
+def get_works_csv_by_person(person_id: str, query_params: QueryParams, pipeline_params: dict) -> Generator:
+    pipeline: List[Dict[str, Any]] = [
         {"$match": {"authors.id": person_id}},
     ]
+    base_repository.set_project(pipeline, pipeline_params.get("project"))
     work_repository.set_product_filters(pipeline, query_params)
-    pipeline += [
-        {
-            "$project": {
-                "external_ids": 1,
-                "authors": 1,
-                "bibliographic_info": 1,
-                "open_access": 1,
-                "citations_count": 1,
-                "subjects": 1,
-                "titles": 1,
-                "types": 1,
-                "source": 1,
-                "groups": 1,
-                "year_published": 1,
-                "ranking": 1,
-                "primary_topic": 1,
-                "doi": 1,
-            }
-        },
-    ]
     cursor = database["works"].aggregate(pipeline)
     return work_generator.get(cursor)
 
 
-def get_works_csv_by_affiliation(affiliation_id: str, query_params: QueryParams, affiliation_type: str) -> Generator:
-    pipeline = [
+def get_works_csv_by_affiliation(
+    affiliation_id: str, query_params: QueryParams, affiliation_type: str, pipeline_params: dict
+) -> Generator:
+    pipeline: List[Dict[str, Any]] = [
         {"$match": {"authors.affiliations.id": affiliation_id, "authors.affiliations.types.type": affiliation_type}},
     ]
+    base_repository.set_project(pipeline, pipeline_params.get("project"))
     work_repository.set_product_filters(pipeline, query_params)
-    pipeline += [
-        {
-            "$project": {
-                "external_ids": 1,
-                "authors": 1,
-                "bibliographic_info": 1,
-                "open_access": 1,
-                "citations_count": 1,
-                "subjects": 1,
-                "titles": 1,
-                "types": 1,
-                "source": 1,
-                "groups": 1,
-                "year_published": 1,
-                "ranking": 1,
-                "primary_topic": 1,
-                "doi": 1,
-            }
-        }
+    cursor = database["works"].aggregate(pipeline)
+    return work_generator.get(cursor)
+
+
+def get_works_csv_by_source(source_id: str, query_params: QueryParams, pipeline_params: dict) -> Generator:
+    """
+    Query database for works from a specific source using MongoDB aggregation.
+
+    Builds and executes a MongoDB aggregation pipeline that:
+    1. Filters works by source ID
+    2. Projects only necessary fields (from pipeline_params)
+    3. Applies additional filters from query_params (dates, types, etc.)
+    4. Returns results as a generator
+
+    Args:
+        source_id: Source identifier to filter works
+        query_params: Additional filters (pagination, date ranges, etc.)
+        pipeline_params: Projection parameters defining which fields to retrieve
+
+    Returns:
+        Generator: Generator yielding Work objects from database cursor
+
+    Note:
+        Uses generator to avoid loading all works into memory at once,
+        which is critical for sources with thousands of publications
+    """
+    pipeline: List[Dict[str, Any]] = [
+        {"$match": {"source.id": ObjectId(source_id)}},
     ]
+    base_repository.set_project(pipeline, pipeline_params.get("project"))
+    work_repository.set_product_filters(pipeline, query_params)
     cursor = database["works"].aggregate(pipeline)
     return work_generator.get(cursor)


### PR DESCRIPTION
### Hot Fixes

- Applied changes for api_expert: moved a line to apply filters earlier
- Removed the affiliation_type field from the product search used to generate CSVs for affiliation products.