### PR TITLE
Docker Fix – APIDoc Overwrite Issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.10-slim AS base
 
+WORKDIR /app
+
 ENV \ 
 	PIP_NO_CACHE_DIR=off \ 
 	PIP_DISABLE_PIP_VERSION_CHECK=on \ 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,10 @@ services:
       dockerfile: Dockerfile
       target: development
     image: colav/quyca-dev:dev
-    volumes:
-      - .:/app
     working_dir: /app
     environment:
       PYTHONPATH: /quyca
-    entrypoint: [ "poetry", "run", "python", "./quyca/app.py" ]
-
+    entrypoint: ["poetry", "run", "python", "./quyca/app.py"]
 
   prod:
     container_name: quyca-prod
@@ -63,4 +60,4 @@ services:
     working_dir: /app
     environment:
       PYTHONPATH: /quyca
-    entrypoint: [ "poetry", "run", "python", "./quyca/app.py" ]
+    entrypoint: ["poetry", "run", "python", "./quyca/app.py"]


### PR DESCRIPTION
This PR includes a small but important fix related to the APIDoc generation and container behavior:

- Added WORKDIR /app as the second line in the Dockerfile to ensure a consistent working directory across all stages.
- Removed the following volume mapping from docker-compose.yml **[JUST FOR `DEV`]**:
```dockerfile
volumes:
  - .:/app
```

#### 🐛Cause

The volume mount was overwriting the generated `APIDoc` static files inside the container. Since these `.html` files are generated during the build stage and do not exist in the local project, the documentation was not visible at runtime.

>[!TIP]
> By removing the volume mount the generated APIDoc files from the build stage are now preserved.