### PR TITLE
[hotfix] disable default rate limits to prevent blocking /app routes

### DIFF
--- a/quyca/application/routes/router.py
+++ b/quyca/application/routes/router.py
@@ -27,12 +27,7 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from config import settings
 
-limiter = Limiter(
-    get_remote_address, 
-    storage_uri=str(settings.MONGO_URI), 
-    strategy="fixed-window",
-    default_limits=[]
-)
+limiter = Limiter(get_remote_address, storage_uri=str(settings.MONGO_URI), strategy="fixed-window", default_limits=[])
 
 for limit in settings.API_LIMITS.split(","):
     limiter.limit(limit)(person_api_router)

--- a/quyca/application/routes/router.py
+++ b/quyca/application/routes/router.py
@@ -27,7 +27,12 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from config import settings
 
-limiter = Limiter(get_remote_address, storage_uri=str(settings.MONGO_URI), strategy="fixed-window")
+limiter = Limiter(
+    get_remote_address, 
+    storage_uri=str(settings.MONGO_URI), 
+    strategy="fixed-window",
+    default_limits=[]
+)
 
 for limit in settings.API_LIMITS.split(","):
     limiter.limit(limit)(person_api_router)


### PR DESCRIPTION
- Set default_limits=[] in Limiter initialization
- Rate limits now only apply to explicitly configured API routes
- Fixes issue where 10 req/sec limit was blocking Playwright tests after 9 requests
- /app routes no longer affected by rate limiting, only /api routes remain protected"