### PR TITLE
Issn warning fix

### DIFF
--- a/quyca/domain/parsers/work_parser.py
+++ b/quyca/domain/parsers/work_parser.py
@@ -102,14 +102,13 @@ def parse_works_by_entity(works: list) -> list:
 
 
 def parse_work(work: Work) -> dict:
-    return dict(work.model_dump(exclude_none=True))
+    fields_exclude = {"abstracts"}
+    return dict(work.model_dump(exclude=fields_exclude, exclude_none=True))
 
 
 def parse_api_expert(works: list) -> list:
-    field_exclude = {
-        "abstracts",
-    }
-    return [work.model_dump(exclude=field_exclude, exclude_none=True) for work in works]
+    fields_exclude = {"abstracts"}
+    return [work.model_dump(exclude=fields_exclude, exclude_none=True) for work in works]
 
 
 def parse_available_filters(filters: dict) -> dict:

--- a/quyca/domain/services/csv_service.py
+++ b/quyca/domain/services/csv_service.py
@@ -6,7 +6,7 @@ from quyca.domain.models.work_model import BiblioGraphicInfo, Work
 from quyca.infrastructure.repositories import csv_repository
 from quyca.domain.constants.institutions import institutions_list
 from quyca.domain.constants.openalex_types import openalex_types_dict
-from quyca.domain.services import work_service
+from quyca.domain.services import source_service, work_service
 from quyca.domain.parsers import work_parser
 
 
@@ -96,6 +96,7 @@ def get_csv_data(works: Generator) -> list:
         work_service.set_title_and_language(work)
         set_csv_types(work)
         set_primary_topic(work)
+        source_service.update_csv_work_source(work)
         data.append(work)
     return data
 

--- a/quyca/domain/services/csv_service.py
+++ b/quyca/domain/services/csv_service.py
@@ -6,7 +6,6 @@ from quyca.domain.models.work_model import BiblioGraphicInfo, Work
 from quyca.infrastructure.repositories import csv_repository
 from quyca.domain.constants.institutions import institutions_list
 from quyca.domain.constants.openalex_types import openalex_types_dict
-from quyca.domain.services import source_service
 from quyca.domain.services import work_service
 from quyca.domain.parsers import work_parser
 
@@ -97,7 +96,6 @@ def get_csv_data(works: Generator) -> list:
         work_service.set_title_and_language(work)
         set_csv_types(work)
         set_primary_topic(work)
-        source_service.update_csv_work_source(work)
         data.append(work)
     return data
 

--- a/quyca/domain/services/source_service.py
+++ b/quyca/domain/services/source_service.py
@@ -1,6 +1,47 @@
 from infrastructure.repositories import source_repository
 from quyca.domain.models.base_model import QueryParams
+from quyca.domain.models.work_model import Work, Source
 from quyca.domain.parsers import source_parser
+
+
+def update_csv_work_source(work: Work) -> None:
+    if not work.source:
+        return
+
+    source = work.source
+    work.source_name = str(source.name) if source.name else None
+    if source.apc and source.apc.charges and source.apc.currency:
+        work.source_apc = f"{source.apc.charges} / {source.apc.currency}"
+    else:
+        work.source_apc = None
+
+    set_source_urls(work, source)
+    set_scimago_quartile(work, source)
+
+
+def set_source_urls(work: Work, source: Source) -> None:
+    if source.external_urls:
+        urls = {str(url.url) for url in source.external_urls if url.url}
+        work.source_urls = " | ".join(urls) if urls else None
+    else:
+        work.source_urls = None
+
+
+def set_scimago_quartile(work: Work, source: Source) -> None:
+    work.scimago_quartile = None
+    if source.ranking and work.date_published:
+        for ranking in source.ranking:
+            condition = (
+                ranking.source == "scimago Best Quartile"
+                and ranking.rank
+                and ranking.rank != "-"
+                and isinstance(ranking.from_date, int)
+                and isinstance(ranking.to_date, int)
+                and ranking.from_date <= work.date_published <= ranking.to_date
+            )
+            if condition:
+                work.scimago_quartile = str(ranking.rank)
+                break
 
 
 def get_source_by_id(source_id: str) -> dict:

--- a/quyca/domain/services/source_service.py
+++ b/quyca/domain/services/source_service.py
@@ -1,69 +1,6 @@
-from domain.models.source_model import Source
-from domain.models.work_model import Work
 from infrastructure.repositories import source_repository
 from quyca.domain.models.base_model import QueryParams
 from quyca.domain.parsers import source_parser
-
-
-def update_work_source(work: Work) -> None:
-    if not work.source or not work.source.id:
-        return
-
-    source = source_repository.get_source_by_id(work.source.id)
-
-    if not source:
-        return
-
-    set_serials(work, source)
-    set_scimago_quartile(work, source)
-
-
-def update_csv_work_source(work: Work) -> None:
-    if not work.source:
-        return
-
-    source = work.source
-    work.source_name = str(source.name) if source.name else None
-    if source.apc and source.apc.charges and source.apc.currency:
-        work.source_apc = f"{source.apc.charges} / {source.apc.currency}"
-    else:
-        work.source_apc = None
-
-    set_source_urls(work, source)
-    set_scimago_quartile(work, source)
-
-
-def set_source_urls(work: Work, source: Source) -> None:
-    if source.external_urls:
-        urls = {str(url.url) for url in source.external_urls if url.url}
-        work.source_urls = " | ".join(urls) if urls else None
-    else:
-        work.source_urls = None
-
-
-def set_scimago_quartile(work: Work, source: Source) -> None:
-    work.scimago_quartile = None
-    if source.ranking and work.date_published:
-        for ranking in source.ranking:
-            condition = (
-                ranking.source == "scimago Best Quartile"
-                and ranking.rank
-                and ranking.rank != "-"
-                and isinstance(ranking.from_date, int)
-                and isinstance(ranking.to_date, int)
-                and ranking.from_date <= work.date_published <= ranking.to_date
-            )
-            if condition:
-                work.scimago_quartile = str(ranking.rank)
-                break
-
-
-def set_serials(work: Work, source: Source) -> None:
-    if source.external_ids:
-        external_ids = {}
-        for external_id in source.external_ids:
-            external_ids[external_id.source] = external_id.id
-        work.source.external_ids = external_ids
 
 
 def get_source_by_id(source_id: str) -> dict:

--- a/quyca/domain/services/work_service.py
+++ b/quyca/domain/services/work_service.py
@@ -3,7 +3,6 @@ from typing import Generator
 from quyca.domain.models.base_model import QueryParams
 from quyca.domain.models.work_model import Work, Abstract
 from quyca.infrastructure.repositories import work_repository
-from quyca.domain.services import source_service
 from quyca.domain.services.base_service import (
     limit_authors,
     set_title_and_language,
@@ -22,7 +21,6 @@ def get_work_by_id(work_id: str) -> dict:
     set_external_urls(work)
     limit_authors(work)
     set_authors_external_ids(work)
-    source_service.update_work_source(work)
     set_title_and_language(work)
     set_product_types(work)
     data = work_parser.parse_work(work)


### PR DESCRIPTION
Solving this pydantic's warning:
```python
/venv/lib/python3.10/site-packages/pydantic/main.py:387: UserWarning: Pydantic serializer warnings: 
Expected list[definition-ref] but got dict with value {'issn': '1532-3064', 'sc...openalex.org/S71995303'}
- serialized value may not be as expected return self.__pydantic_serializer__.to_python(
```

#### Remove unnecessary `update_work` and `set_serials` **functions** 🧹

I removed the `update_work` and `set_serials` functions because they were no longer needed. The work documents are already fully enriched **(denormalization)** with the required source-related fields, making these additional update steps redundant.