### PR TITLE
Fixing some sources details

### DIFF
--- a/quyca/domain/constants/source_types.py
+++ b/quyca/domain/constants/source_types.py
@@ -6,6 +6,7 @@ TYPE_DISPLAY_MAPPING = {
     "metadata": "Metadatos",
     "other": "Otro",
     "repository": "Repositorio",
+    "not_specified": "No especificado",
 }
 
 NORMALIZED_TYPE_MAPPING = {
@@ -36,3 +37,9 @@ SOURCE_TITLES = {
 }
 
 QUARTILE_MAPPING = {"-": "Sin cuartil"}
+
+
+def normalize_source_type(raw_type: str | None) -> str:
+    if not raw_type:
+        return "not_specified"
+    return NORMALIZED_TYPE_MAPPING.get(raw_type, "not_specified")

--- a/quyca/domain/constants/source_types.py
+++ b/quyca/domain/constants/source_types.py
@@ -1,31 +1,32 @@
 TYPE_DISPLAY_MAPPING = {
-    "journal": "revista",
-    "trade journal": "revista especializada",
-    "book series": "serie de libros",
-    "conference": "conferencia",
-    "conference and proceedings": "conferencia y memorias de congreso",
-    "ebook platform": "plataforma de libros electrónicos",
-    "metadata": "metadatos",
-    "other": "otro",
-    "repository": "repositorio",
+    "journal": "Revista",
+    "book series": "Serie de libros",
+    "conference": "Conferencia",
+    "ebook platform": "Plataforma de libros electrónicos",
+    "metadata": "Metadatos",
+    "other": "Otro",
+    "repository": "Repositorio",
 }
 
 NORMALIZED_TYPE_MAPPING = {
+    # Scienti types
     "E": "journal",
     "EL": "journal",
     "IE": "journal",
     "IM": "journal",
     "L": "journal",
     "P": "journal",
+    # OpenAlex types
     "journal": "journal",
-    "trade journal": "trade journal",
     "book series": "book series",
     "conference": "conference",
-    "conference and proceedings": "conference and proceedings",
     "ebook platform": "ebook platform",
     "metadata": "metadata",
     "repository": "repository",
     "other": "other",
+    # Scimago types
+    "trade journal": "journal",
+    "conference and proceedings": "conference",
 }
 
 SOURCE_TITLES = {
@@ -34,4 +35,4 @@ SOURCE_TITLES = {
     "scienti": "Scienti",
 }
 
-QUARTILE_MAPPING = {"Q1": "Q1", "Q2": "Q2", "Q3": "Q3", "Q4": "Q4", "-": "Sin cuartil"}
+QUARTILE_MAPPING = {"-": "Sin cuartil"}

--- a/quyca/domain/models/source_model.py
+++ b/quyca/domain/models/source_model.py
@@ -64,6 +64,7 @@ class Source(BaseModel):
     review_processes: list | None = None
     subjects: list[Subject] | None = None
     topics: list[Topic] | None = None
+    type: str | None = None
     types: list[Type] | None = None
     updated: list[Updated] | None = None
     waiver: Waiver | None = None

--- a/quyca/domain/parsers/source_parser.py
+++ b/quyca/domain/parsers/source_parser.py
@@ -14,7 +14,7 @@ def parse_source(source: Source) -> dict[str, Any]:
         "updated",
         "names",
         "abbreviations",
-        "types",
+        "type",
         "keywords",
         "languages",
         "publisher",
@@ -134,12 +134,12 @@ def parse_source_type_filter(source_types: List) -> List:
         if not raw_type:
             continue
 
-        normalized = NORMALIZED_TYPE_MAPPING.get(raw_type, "other")
+        normalized = NORMALIZED_TYPE_MAPPING.get(raw_type, "not_specified")
         type_counts[normalized] = type_counts.get(normalized, 0) + count
 
     children: List[Dict[str, int | str]] = []
     for normalized_type, total_count in type_counts.items():
-        title = TYPE_DISPLAY_MAPPING.get(normalized_type, normalized_type)
+        title = TYPE_DISPLAY_MAPPING.get(normalized_type, "not_specified")
 
         children.append(
             {

--- a/quyca/domain/parsers/source_parser.py
+++ b/quyca/domain/parsers/source_parser.py
@@ -131,10 +131,10 @@ def parse_source_type_filter(source_types: List) -> List:
         raw_type = type_doc.get("_id")
         count = type_doc.get("count", 0)
 
-        if not raw_type:
-            continue
-
-        normalized = NORMALIZED_TYPE_MAPPING.get(raw_type, "not_specified")
+        if raw_type is None:
+            normalized = "not_specified"
+        else:
+            normalized = NORMALIZED_TYPE_MAPPING.get(raw_type, "not_specified")
         type_counts[normalized] = type_counts.get(normalized, 0) + count
 
     children: List[Dict[str, int | str]] = []

--- a/quyca/domain/parsers/source_parser.py
+++ b/quyca/domain/parsers/source_parser.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List
 from quyca.domain.constants.source_types import (
     NORMALIZED_TYPE_MAPPING,
     QUARTILE_MAPPING,
-    SOURCE_TITLES,
     TYPE_DISPLAY_MAPPING,
 )
 from quyca.domain.models.source_model import Source
@@ -59,7 +58,6 @@ def parse_search_result(sources: List) -> List:
         "updated",
         "names",
         "abbreviations",
-        "types",
         "keywords",
         "languages",
         "publisher",
@@ -80,6 +78,7 @@ def parse_search_result(sources: List) -> List:
         "ranking",
         "review_process",
         "topics",
+        "type",
     ]
 
     return [
@@ -126,48 +125,33 @@ def parse_source_type_filter(source_types: List) -> List:
     List
         A List containing the parsed source type filter.
     """
-    parsed_sources: List = []
+    type_counts: Dict[str, int] = {}
 
-    for source_doc in source_types:
-        source_id = source_doc.get("_id")
-        if not source_id:
+    for type_doc in source_types:
+        raw_type = type_doc.get("_id")
+        count = type_doc.get("count", 0)
+
+        if not raw_type:
             continue
 
-        types = source_doc.get("types", [])
-        type_counts: Dict[str, int] = {}
+        normalized = NORMALIZED_TYPE_MAPPING.get(raw_type, "other")
+        type_counts[normalized] = type_counts.get(normalized, 0) + count
 
-        for t in types:
-            raw_type = t.get("type")
-            count = t.get("count", 0)
+    children: List[Dict[str, int | str]] = []
+    for normalized_type, total_count in type_counts.items():
+        title = TYPE_DISPLAY_MAPPING.get(normalized_type, normalized_type)
 
-            if not raw_type:
-                continue
-
-            normalized = NORMALIZED_TYPE_MAPPING.get(raw_type, "other")
-            type_counts[normalized] = type_counts.get(normalized, 0) + count
-
-        children: List[Dict[str, int | str]] = []
-        for normalized_type, total_count in type_counts.items():
-            title = TYPE_DISPLAY_MAPPING.get(normalized_type, normalized_type)
-            value = f"{source_id}_{title}"
-
-            children.append(
-                {
-                    "value": value,
-                    "title": title,
-                    "count": total_count,
-                }
-            )
-
-        children.sort(key=lambda c: c["count"], reverse=True)
-
-        parsed_sources.append(
-            {"value": source_id, "title": SOURCE_TITLES.get(source_id, source_id), "children": children}
+        children.append(
+            {
+                "value": normalized_type,
+                "title": title,
+                "count": total_count,
+            }
         )
 
-    parsed_sources.sort(key=lambda s: s["title"])
+    children.sort(key=lambda c: c["count"], reverse=True)
 
-    return parsed_sources
+    return children
 
 
 def parse_scimago_quartile_filter(quartiles: List) -> List:

--- a/quyca/infrastructure/repositories/source_repository.py
+++ b/quyca/infrastructure/repositories/source_repository.py
@@ -78,6 +78,7 @@ def search_sources(query_params: QueryParams, pipeline_params: dict) -> Tuple[Ge
     if query_params.keywords:
         pipeline.append({"$match": {"$text": {"$search": query_params.keywords}}})
     set_source_filters(pipeline, query_params)
+    set_source_type_pipeline(pipeline)
     base_repository.set_search_end_stages(pipeline, query_params, pipeline_params)
     raw_sources = database["sources"].aggregate(pipeline)
 
@@ -141,8 +142,12 @@ def get_search_sources_available_filters(query_params: QueryParams) -> dict:
                 "source_types": [
                     {"$project": {"types": 1}},
                     {"$unwind": "$types"},
-                    {"$group": {"_id": {"source": "$types.source", "type": "$types.type"}, "count": {"$sum": 1}}},
-                    {"$group": {"_id": "$_id.source", "types": {"$push": {"type": "$_id.type", "count": "$count"}}}},
+                    {
+                        "$group": {
+                            "_id": {"doc_id": "$_id", "type": "$types.type"},
+                        }
+                    },
+                    {"$group": {"_id": "$_id.type", "count": {"$sum": 1}}},
                 ],
                 "scimago_quartiles": [
                     {"$project": {"ranking": 1}},
@@ -175,6 +180,46 @@ def get_search_sources_available_filters(query_params: QueryParams) -> dict:
 
     available_filters: dict = next(database["sources"].aggregate(pipeline), {})
     return available_filters
+
+
+def set_source_type_pipeline(pipeline: list) -> None:
+    pipeline.append(
+        {
+            "$addFields": {
+                "type": {
+                    "$switch": {
+                        "branches": [
+                            {
+                                "case": {"$in": ["scimago", "$types.source"]},
+                                "then": {
+                                    "$arrayElemAt": ["$types.type", {"$indexOfArray": ["$types.source", "scimago"]}]
+                                },
+                            },
+                            {
+                                "case": {"$in": ["doaj", "$types.source"]},
+                                "then": {"$arrayElemAt": ["$types.type", {"$indexOfArray": ["$types.source", "doaj"]}]},
+                            },
+                            {
+                                "case": {"$in": ["scienti", "$types.source"]},
+                                "then": {
+                                    "$arrayElemAt": ["$types.type", {"$indexOfArray": ["$types.source", "scienti"]}]
+                                },
+                            },
+                            {
+                                "case": {"$in": ["openalex", "$types.source"]},
+                                "then": {
+                                    "$arrayElemAt": ["$types.type", {"$indexOfArray": ["$types.source", "openalex"]}]
+                                },
+                            },
+                        ],
+                        "default": None,
+                    }
+                }
+            }
+        }
+    )
+
+    pipeline.append({"$unset": "types"})
 
 
 def set_source_filters(pipeline: list, query_params: QueryParams) -> None:

--- a/quyca/infrastructure/repositories/source_repository.py
+++ b/quyca/infrastructure/repositories/source_repository.py
@@ -6,7 +6,7 @@ from infrastructure.repositories import base_repository
 from infrastructure.generators import source_generator
 from domain.models.source_model import Source
 from domain.exceptions.not_entity_exception import NotEntityException
-from quyca.domain.constants.source_types import NORMALIZED_TYPE_MAPPING
+from quyca.domain.constants.source_types import NORMALIZED_TYPE_MAPPING, normalize_source_type
 from quyca.domain.models.base_model import QueryParams
 
 
@@ -26,9 +26,17 @@ def get_source_by_id(source_id: str) -> Source:
         If no source with the given source_id exists in the database.
     """
     source_object_id = ObjectId(source_id)
-    source_data = database["sources"].find_one({"_id": source_object_id})
+    pipeline: list[dict[str, Any]] = [
+        {"$match": {"_id": source_object_id}},
+    ]
+    set_source_type_pipeline(pipeline)
+
+    source_data = next(database["sources"].aggregate(pipeline), None)
     if not source_data:
         raise NotEntityException(f"The source with id {source_id} does not exist.")
+
+    raw_type = source_data.get("type")
+    source_data["type"] = normalize_source_type(raw_type)
 
     works_count = database["works"].count_documents({"source.id": source_object_id})
     if works_count == 0:
@@ -92,7 +100,7 @@ def search_sources(query_params: QueryParams, pipeline_params: dict) -> Tuple[Ge
             continue
         topics_limit = works_count * 0.02
         topic_pipeline = [
-            {"$match": {"source.id": s_id, "primary_topic": {"$exists": True, "$ne": None}}},
+            {"$match": {"source.id": s_id, "primary_topic.id": {"$exists": True, "$ne": None}}},
             {"$project": {"_id": 0, "primary_topic": 1}},
             {"$group": {"_id": "$primary_topic.id", "count": {"$sum": 1}, "topic": {"$first": "$primary_topic"}}},
             {"$match": {"count": {"$gte": topics_limit}}},
@@ -187,33 +195,44 @@ def set_source_type_pipeline(pipeline: list) -> None:
         {
             "$addFields": {
                 "type": {
-                    "$switch": {
-                        "branches": [
-                            {
-                                "case": {"$in": ["scimago", "$types.source"]},
-                                "then": {
-                                    "$arrayElemAt": ["$types.type", {"$indexOfArray": ["$types.source", "scimago"]}]
+                    "$arrayElemAt": [
+                        {
+                            "$filter": {
+                                "input": {
+                                    "$map": {
+                                        "input": ["scimago", "doaj", "scienti", "openalex"],
+                                        "as": "src",
+                                        "in": {
+                                            "$arrayElemAt": [
+                                                {
+                                                    "$map": {
+                                                        "input": {
+                                                            "$filter": {
+                                                                "input": "$types",
+                                                                "as": "t",
+                                                                "cond": {
+                                                                    "$and": [
+                                                                        {"$eq": ["$$t.source", "$$src"]},
+                                                                        {"$ne": ["$$t.type", None]},
+                                                                    ]
+                                                                },
+                                                            }
+                                                        },
+                                                        "as": "t",
+                                                        "in": "$$t.type",
+                                                    }
+                                                },
+                                                0,
+                                            ]
+                                        },
+                                    }
                                 },
-                            },
-                            {
-                                "case": {"$in": ["doaj", "$types.source"]},
-                                "then": {"$arrayElemAt": ["$types.type", {"$indexOfArray": ["$types.source", "doaj"]}]},
-                            },
-                            {
-                                "case": {"$in": ["scienti", "$types.source"]},
-                                "then": {
-                                    "$arrayElemAt": ["$types.type", {"$indexOfArray": ["$types.source", "scienti"]}]
-                                },
-                            },
-                            {
-                                "case": {"$in": ["openalex", "$types.source"]},
-                                "then": {
-                                    "$arrayElemAt": ["$types.type", {"$indexOfArray": ["$types.source", "openalex"]}]
-                                },
-                            },
-                        ],
-                        "default": None,
-                    }
+                                "as": "item",
+                                "cond": {"$ne": ["$$item", None]},
+                            }
+                        },
+                        0,
+                    ]
                 }
             }
         }

--- a/quyca/infrastructure/repositories/source_repository.py
+++ b/quyca/infrastructure/repositories/source_repository.py
@@ -148,14 +148,16 @@ def get_search_sources_available_filters(query_params: QueryParams) -> dict:
         {
             "$facet": {
                 "source_types": [
-                    {"$project": {"types": 1}},
-                    {"$unwind": "$types"},
                     {
-                        "$group": {
-                            "_id": {"doc_id": "$_id", "type": "$types.type"},
+                        "$project": {
+                            "single_type": {
+                                "$first": {
+                                    "$filter": {"input": "$types.type", "as": "t", "cond": {"$ne": ["$$t", None]}}
+                                }
+                            }
                         }
                     },
-                    {"$group": {"_id": "$_id.type", "count": {"$sum": 1}}},
+                    {"$group": {"_id": "$single_type", "count": {"$sum": 1}}},
                 ],
                 "scimago_quartiles": [
                     {"$project": {"ranking": 1}},
@@ -237,8 +239,6 @@ def set_source_type_pipeline(pipeline: list) -> None:
             }
         }
     )
-
-    pipeline.append({"$unset": "types"})
 
 
 def set_source_filters(pipeline: list, query_params: QueryParams) -> None:


### PR DESCRIPTION
#### 🎯 Denormalize source types and unify type filters

This PR denormalizes the types field in sources to extract a single type value with source priority hierarchy, and unifies type filters across all sources into a single consolidated list.

### Source Type Denormalization

- Added `set_source_type_pipeline()` function to extract type from types array
- Implemented priority hierarchy: **scimago > doaj > scienti > openalex**
- Removed types array from response, replaced with single type field

```python
# Before
types: [{source: 'openalex', type: 'journal'}]
# After
type: 'journal'
```

### Unified Type Filters 🔀

- Refactored aggregation pipeline to consolidate types across all sources
- Updated `parse_source_type_filter()` to return flat list instead of grouped-by-source structure
- Normalized type mappings:

   - trade journal → journal
   - conference and proceedings → conference

**Like proposed in [this issue](https://github.com/colav/impactu/issues/584)**

### Optimizations ⚡

- Removed redundant `$sort` stage from `source_types` facet (sorting done in parser)
- Simplified `QUARTILE_MAPPING` to only map - → "Sin cuartil"

### 📊 Before vs After
**Before:**
```json
"source_types": [
    {
      "children": [
        {
          "count": 209322,
          "title": "Revista",
          "value": "journal"
        },
     ]
   }
]
```
**After:**
```json
"source_types": [
  {
      "count": 230199,
      "title": "Revista",
      "value": "journal"
   },
]
```