### PR TITLE
Package imports structure changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,11 +44,6 @@ pytest-asyncio = "^0.20.3"
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 ignore_missing_imports = true
-warn_return_any = true
-warn_unused_ignores = true
-warn_redundant_casts = true
-check_untyped_defs = true
-show_error_codes = true
 mypy_path = "."
 
 [build-system]

--- a/quyca/app.py
+++ b/quyca/app.py
@@ -7,8 +7,8 @@ from flask_compress import Compress
 from flask_cors import CORS
 from sentry_sdk.integrations.flask import FlaskIntegration
 
-from application.routes.router import router, limiter
-from config import Settings
+from quyca.application.routes.router import router, limiter
+from quyca.config import Settings
 
 
 def create_app() -> Flask:

--- a/quyca/application/routes/api/affiliation_api_router.py
+++ b/quyca/application/routes/api/affiliation_api_router.py
@@ -3,8 +3,8 @@ from typing import Tuple
 from flask import Blueprint, jsonify, request, Response
 from sentry_sdk import capture_exception
 
-from domain.models.base_model import QueryParams
-from domain.services import api_expert_service
+from quyca.domain.models.base_model import QueryParams
+from quyca.domain.services import api_expert_service
 
 affiliation_api_router = Blueprint("affiliation_api_router", __name__)
 

--- a/quyca/application/routes/api/apc_api_router.py
+++ b/quyca/application/routes/api/apc_api_router.py
@@ -5,8 +5,8 @@ from typing import Any, Generator, Iterable, Tuple
 from flask import Blueprint, request, jsonify, Response
 from sentry_sdk import capture_exception
 
-from domain.models.base_model import QueryParams
-from infrastructure.mongo import database
+from quyca.domain.models.base_model import QueryParams
+from quyca.infrastructure.mongo import database
 
 apc_api_router = Blueprint("apc_api_router", __name__)
 

--- a/quyca/application/routes/api/person_api_router.py
+++ b/quyca/application/routes/api/person_api_router.py
@@ -3,8 +3,8 @@ from typing import Tuple
 from flask import Blueprint, request, jsonify, Response
 from sentry_sdk import capture_exception
 
-from domain.models.base_model import QueryParams
-from domain.services import api_expert_service, news_service, person_service
+from quyca.domain.models.base_model import QueryParams
+from quyca.domain.services import api_expert_service, news_service, person_service
 
 person_api_router = Blueprint("person_api_router", __name__)
 

--- a/quyca/application/routes/api/search_api_router.py
+++ b/quyca/application/routes/api/search_api_router.py
@@ -4,8 +4,8 @@ from flask import Blueprint, url_for, redirect, request, Response, jsonify
 from werkzeug.wrappers.response import Response as WerkzeugResponse
 from sentry_sdk import capture_exception
 
-from domain.models.base_model import QueryParams
-from domain.services import api_expert_service
+from quyca.domain.models.base_model import QueryParams
+from quyca.domain.services import api_expert_service
 
 search_api_router = Blueprint("search_api_router", __name__)
 

--- a/quyca/application/routes/api/source_api_router.py
+++ b/quyca/application/routes/api/source_api_router.py
@@ -1,7 +1,7 @@
 from typing import Tuple
 from flask import Blueprint, request, jsonify, Response
 
-from domain.models.base_model import QueryParams
+from quyca.domain.models.base_model import QueryParams
 from quyca.domain.services import api_expert_service
 
 source_api_router = Blueprint("source_api_router", __name__)

--- a/quyca/application/routes/app/affiliation_app_router.py
+++ b/quyca/application/routes/app/affiliation_app_router.py
@@ -4,8 +4,8 @@ from typing import Tuple
 from flask import Blueprint, request, Response, jsonify
 from sentry_sdk import capture_exception
 
-from domain.models.base_model import QueryParams
-from domain.services import (
+from quyca.domain.models.base_model import QueryParams
+from quyca.domain.services import (
     work_service,
     affiliation_service,
     project_service,

--- a/quyca/application/routes/app/ciarp_app_router.py
+++ b/quyca/application/routes/app/ciarp_app_router.py
@@ -3,8 +3,8 @@ from zoneinfo import ZoneInfo
 from typing import Any
 from flask_jwt_extended import verify_jwt_in_request, get_jwt
 from flask import Blueprint, request, jsonify
-from infrastructure.container import build_ciarp_service
-from domain.services.ciarp_service import CiarpService
+from quyca.infrastructure.container import build_ciarp_service
+from quyca.domain.services.ciarp_service import CiarpService
 
 ciarp_app_router = Blueprint("ciarp_app_router", __name__)
 

--- a/quyca/application/routes/app/completer_app_router.py
+++ b/quyca/application/routes/app/completer_app_router.py
@@ -3,7 +3,7 @@ from typing import Tuple
 from flask import Blueprint, jsonify, Response
 from sentry_sdk import capture_exception
 
-from infrastructure.repositories import completers
+from quyca.infrastructure.repositories import completers
 
 completer_app_router = Blueprint("completer_app_router", __name__)
 

--- a/quyca/application/routes/app/info_app_router.py
+++ b/quyca/application/routes/app/info_app_router.py
@@ -3,7 +3,7 @@ from typing import Tuple
 from flask import Blueprint, jsonify, Response
 from sentry_sdk import capture_exception
 
-from domain.services import (
+from quyca.domain.services import (
     info_service,
 )
 

--- a/quyca/application/routes/app/patent_app_router.py
+++ b/quyca/application/routes/app/patent_app_router.py
@@ -3,7 +3,7 @@ from typing import Tuple
 from flask import Blueprint, jsonify, Response
 from sentry_sdk import capture_exception
 
-from domain.services import patent_service
+from quyca.domain.services import patent_service
 
 patent_app_router = Blueprint("patent_app_router", __name__)
 

--- a/quyca/application/routes/app/project_app_router.py
+++ b/quyca/application/routes/app/project_app_router.py
@@ -3,7 +3,7 @@ from typing import Tuple
 from flask import Blueprint, jsonify, Response
 from sentry_sdk import capture_exception
 
-from domain.services import project_service
+from quyca.domain.services import project_service
 
 project_app_router = Blueprint("project_app_router", __name__)
 

--- a/quyca/application/routes/app/search_app_router.py
+++ b/quyca/application/routes/app/search_app_router.py
@@ -3,8 +3,8 @@ from typing import Tuple
 from flask import Blueprint, request, jsonify, Response
 from sentry_sdk import capture_exception
 
-from domain.models.base_model import QueryParams
-from domain.services import (
+from quyca.domain.models.base_model import QueryParams
+from quyca.domain.services import (
     work_service,
     person_service,
     affiliation_service,

--- a/quyca/application/routes/app/staff_app_router.py
+++ b/quyca/application/routes/app/staff_app_router.py
@@ -3,8 +3,8 @@ from typing import Tuple
 from zoneinfo import ZoneInfo
 from flask_jwt_extended import verify_jwt_in_request, get_jwt
 from flask import Blueprint, request, jsonify, Response
-from infrastructure.container import build_staff_service
-from domain.services.staff_service import StaffService
+from quyca.infrastructure.container import build_staff_service
+from quyca.domain.services.staff_service import StaffService
 
 staff_app_router = Blueprint("staff_app_router", __name__)
 """

--- a/quyca/application/routes/app/user_auth_app_router.py
+++ b/quyca/application/routes/app/user_auth_app_router.py
@@ -1,9 +1,9 @@
 from typing import Tuple
 from flask import Blueprint, request, jsonify, Response
 from sentry_sdk import capture_exception
-from domain.exceptions.not_entity_exception import NotEntityException
-from domain.services import auth_service
-from infrastructure.repositories.user_repository import UserRepositoryMongo
+from quyca.domain.exceptions.not_entity_exception import NotEntityException
+from quyca.domain.services import auth_service
+from quyca.infrastructure.repositories.user_repository import UserRepositoryMongo
 
 user_auth_app_router = Blueprint("user_auth_app_router", __name__)
 

--- a/quyca/application/routes/app/user_crud_app_router.py
+++ b/quyca/application/routes/app/user_crud_app_router.py
@@ -1,8 +1,8 @@
 from typing import Any
 from flask import Blueprint, request, jsonify
 from flask_jwt_extended import verify_jwt_in_request, get_jwt, get_jwt_identity
-from application.usecases.user_crud import UserCrudUseCase
-from domain.exceptions.not_entity_exception import NotEntityException
+from quyca.application.usecases.user_crud import UserCrudUseCase
+from quyca.domain.exceptions.not_entity_exception import NotEntityException
 
 """
 HTTP routes for admin user management (JWT-protected).

--- a/quyca/application/routes/app/work_app_router.py
+++ b/quyca/application/routes/app/work_app_router.py
@@ -3,7 +3,7 @@ from typing import Tuple
 from flask import Blueprint, jsonify, Response
 from sentry_sdk import capture_exception
 
-from domain.services import work_service
+from quyca.domain.services import work_service
 
 work_app_router = Blueprint("work_app_router", __name__)
 

--- a/quyca/application/routes/ping_router.py
+++ b/quyca/application/routes/ping_router.py
@@ -1,6 +1,6 @@
 from flask import Blueprint
 
-from config import settings
+from quyca.config import settings
 
 ping_router = Blueprint("ping_router", __name__)
 

--- a/quyca/application/routes/router.py
+++ b/quyca/application/routes/router.py
@@ -1,31 +1,31 @@
 from flask import Blueprint
 
-from application.routes.api.apc_api_router import apc_api_router
-from application.routes.app.info_app_router import info_app_router
-from config import settings
-from application.routes.app.patent_app_router import patent_app_router
-from application.routes.app.project_app_router import project_app_router
-from application.routes.app.search_app_router import search_app_router
-from application.routes.api.search_api_router import search_api_router
-from application.routes.app.affiliation_app_router import affiliation_app_router
-from application.routes.api.affiliation_api_router import affiliation_api_router
-from application.routes.app.user_auth_app_router import user_auth_app_router
-from application.routes.app.user_crud_app_router import user_crud_app_router
-from application.routes.app.staff_app_router import staff_app_router
-from application.routes.app.ciarp_app_router import ciarp_app_router
-from application.routes.app.person_app_router import person_app_router
-from application.routes.api.person_api_router import person_api_router
-from application.routes.app.source_app_router import source_app_router
-from application.routes.api.source_api_router import source_api_router
-from application.routes.app.work_app_router import work_app_router
-from application.routes.docs_router import router as docs_router
-from application.routes.ping_router import ping_router
+from quyca.application.routes.api.apc_api_router import apc_api_router
+from quyca.application.routes.app.info_app_router import info_app_router
+from quyca.config import settings
+from quyca.application.routes.app.patent_app_router import patent_app_router
+from quyca.application.routes.app.project_app_router import project_app_router
+from quyca.application.routes.app.search_app_router import search_app_router
+from quyca.application.routes.api.search_api_router import search_api_router
+from quyca.application.routes.app.affiliation_app_router import affiliation_app_router
+from quyca.application.routes.api.affiliation_api_router import affiliation_api_router
+from quyca.application.routes.app.user_auth_app_router import user_auth_app_router
+from quyca.application.routes.app.user_crud_app_router import user_crud_app_router
+from quyca.application.routes.app.staff_app_router import staff_app_router
+from quyca.application.routes.app.ciarp_app_router import ciarp_app_router
+from quyca.application.routes.app.person_app_router import person_app_router
+from quyca.application.routes.api.person_api_router import person_api_router
+from quyca.application.routes.app.source_app_router import source_app_router
+from quyca.application.routes.api.source_api_router import source_api_router
+from quyca.application.routes.app.work_app_router import work_app_router
+from quyca.application.routes.docs_router import router as docs_router
+from quyca.application.routes.ping_router import ping_router
 
-from application.routes.app.completer_app_router import completer_app_router
+from quyca.application.routes.app.completer_app_router import completer_app_router
 
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
-from config import settings
+from quyca.config import settings
 
 limiter = Limiter(get_remote_address, storage_uri=str(settings.MONGO_URI), strategy="fixed-window", default_limits=[])
 

--- a/quyca/application/usecases/process_ciarp_file.py
+++ b/quyca/application/usecases/process_ciarp_file.py
@@ -2,9 +2,9 @@ import os
 import io
 import pandas as pd
 import base64
-from domain.validators.ciarp_validator import CiarpValidator
-from domain.services.ciarp_report_service import CiarpReportService
-from infrastructure.notifications.staff_notification import StaffNotification
+from quyca.domain.validators.ciarp_validator import CiarpValidator
+from quyca.domain.services.ciarp_report_service import CiarpReportService
+from quyca.infrastructure.notifications.staff_notification import StaffNotification
 
 
 class ProcessCiarpFileUseCase:

--- a/quyca/application/usecases/process_staff_file.py
+++ b/quyca/application/usecases/process_staff_file.py
@@ -2,9 +2,9 @@ import os
 import io
 import base64
 import pandas as pd
-from domain.validators.staff_validator import StaffValidator
-from domain.services.staff_report_service import StaffReportService
-from infrastructure.notifications.staff_notification import StaffNotification
+from quyca.domain.validators.staff_validator import StaffValidator
+from quyca.domain.services.staff_report_service import StaffReportService
+from quyca.infrastructure.notifications.staff_notification import StaffNotification
 
 
 class ProcessStaffFileUseCase:

--- a/quyca/application/usecases/save_ciarp_file.py
+++ b/quyca/application/usecases/save_ciarp_file.py
@@ -1,5 +1,5 @@
 from typing import Dict, Any
-from infrastructure.repositories.file_repository import FileRepository
+from quyca.infrastructure.repositories.file_repository import FileRepository
 
 
 class SaveCiarpFileUseCase:

--- a/quyca/application/usecases/save_staff_file.py
+++ b/quyca/application/usecases/save_staff_file.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict
-from infrastructure.repositories.file_repository import FileRepository
+from quyca.infrastructure.repositories.file_repository import FileRepository
 from werkzeug.datastructures import FileStorage
 
 

--- a/quyca/application/usecases/user_crud.py
+++ b/quyca/application/usecases/user_crud.py
@@ -1,8 +1,8 @@
 from typing import Any, Optional, List, cast
-from domain.services.user_service import UserCrudService
-from infrastructure.repositories.user_crud_repository import UserCrudRepository
-from infrastructure.notifications.staff_notification import StaffNotification
-from infrastructure.repositories.gmail_repository import GmailRepository
+from quyca.domain.services.user_service import UserCrudService
+from quyca.infrastructure.repositories.user_crud_repository import UserCrudRepository
+from quyca.infrastructure.notifications.staff_notification import StaffNotification
+from quyca.infrastructure.repositories.gmail_repository import GmailRepository
 
 
 class UserCrudUseCase:

--- a/quyca/domain/parsers/news_parser.py
+++ b/quyca/domain/parsers/news_parser.py
@@ -1,5 +1,5 @@
 from typing import Iterable, List, Dict
-from domain.models.news_model import News
+from quyca.domain.models.news_model import News
 
 
 def parse_news(news: Iterable[News]) -> List[Dict]:

--- a/quyca/domain/parsers/user_parser.py
+++ b/quyca/domain/parsers/user_parser.py
@@ -1,4 +1,4 @@
-from domain.models.user_model import User
+from quyca.domain.models.user_model import User
 
 """ This function extracts the rolID attribute from a User object and returns it inside a dictionary. """
 

--- a/quyca/domain/repositories/user_crud_repository_interface.py
+++ b/quyca/domain/repositories/user_crud_repository_interface.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional, Dict, Any
-from domain.models.user_model import User
+from quyca.domain.models.user_model import User
 
 
 class IUserCrudRepository(ABC):

--- a/quyca/domain/repositories/user_repository_interface.py
+++ b/quyca/domain/repositories/user_repository_interface.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from domain.models.user_model import User
+from quyca.domain.models.user_model import User
 
 
 class IUserRepository(ABC):

--- a/quyca/domain/services/auth_service.py
+++ b/quyca/domain/services/auth_service.py
@@ -1,7 +1,7 @@
 from flask_jwt_extended import create_access_token, decode_token
-from domain.repositories.user_repository_interface import IUserRepository
-from domain.exceptions.not_entity_exception import NotEntityException
-from domain.parsers.user_parser import user_ror_id_and_institution
+from quyca.domain.repositories.user_repository_interface import IUserRepository
+from quyca.domain.exceptions.not_entity_exception import NotEntityException
+from quyca.domain.parsers.user_parser import user_ror_id_and_institution
 
 """
 verifies user credentials using the repository, generates a JWT access token with the 

--- a/quyca/domain/services/ciarp_report_service.py
+++ b/quyca/domain/services/ciarp_report_service.py
@@ -1,10 +1,10 @@
 import io
 import pandas as pd
-from domain.models.staff_report_model import StaffReport
-from domain.validators.ciarp_validator import CiarpValidator
-from domain.repositories.pdf_repository_interface import IPDFRepository
-from infrastructure.repositories.gmail_repository import GmailRepository
-from infrastructure.exporters.xlsx_writer_exporter import XlsxWriteExporter
+from quyca.domain.models.staff_report_model import StaffReport
+from quyca.domain.validators.ciarp_validator import CiarpValidator
+from quyca.domain.repositories.pdf_repository_interface import IPDFRepository
+from quyca.infrastructure.repositories.gmail_repository import GmailRepository
+from quyca.infrastructure.exporters.xlsx_writer_exporter import XlsxWriteExporter
 from quyca.infrastructure.annotators.annotator import Annotator
 
 

--- a/quyca/domain/services/ciarp_service.py
+++ b/quyca/domain/services/ciarp_service.py
@@ -1,7 +1,7 @@
 from typing import Any
-from application.usecases.process_ciarp_file import ProcessCiarpFileUseCase
-from application.usecases.save_ciarp_file import SaveCiarpFileUseCase
-from infrastructure.repositories.user_repository import UserRepositoryMongo
+from quyca.application.usecases.process_ciarp_file import ProcessCiarpFileUseCase
+from quyca.application.usecases.save_ciarp_file import SaveCiarpFileUseCase
+from quyca.infrastructure.repositories.user_repository import UserRepositoryMongo
 
 
 class CiarpService:

--- a/quyca/domain/services/news_service.py
+++ b/quyca/domain/services/news_service.py
@@ -1,6 +1,6 @@
-from domain.models.base_model import QueryParams
-from infrastructure.repositories import news_repository
-from domain.parsers import news_parser
+from quyca.domain.models.base_model import QueryParams
+from quyca.infrastructure.repositories import news_repository
+from quyca.domain.parsers import news_parser
 
 
 def get_news_by_person(person_id: str, query_params: QueryParams) -> dict:

--- a/quyca/domain/services/source_service.py
+++ b/quyca/domain/services/source_service.py
@@ -1,4 +1,4 @@
-from infrastructure.repositories import source_repository
+from quyca.infrastructure.repositories import source_repository
 from quyca.domain.models.base_model import QueryParams
 from quyca.domain.models.work_model import Work, Source
 from quyca.domain.parsers import source_parser

--- a/quyca/domain/services/staff_report_service.py
+++ b/quyca/domain/services/staff_report_service.py
@@ -1,11 +1,11 @@
 import io
 import pandas as pd
-from domain.models.staff_report_model import StaffReport
-from domain.validators.staff_validator import StaffValidator
-from domain.repositories.pdf_repository_interface import IPDFRepository
-from infrastructure.repositories.gmail_repository import GmailRepository
+from quyca.domain.models.staff_report_model import StaffReport
+from quyca.domain.validators.staff_validator import StaffValidator
+from quyca.domain.repositories.pdf_repository_interface import IPDFRepository
+from quyca.infrastructure.repositories.gmail_repository import GmailRepository
 from quyca.infrastructure.annotators.annotator import Annotator
-from infrastructure.exporters.xlsx_writer_exporter import XlsxWriteExporter
+from quyca.infrastructure.exporters.xlsx_writer_exporter import XlsxWriteExporter
 
 
 class StaffReportService:

--- a/quyca/domain/services/staff_service.py
+++ b/quyca/domain/services/staff_service.py
@@ -1,7 +1,7 @@
 from typing import Any
-from application.usecases.process_staff_file import ProcessStaffFileUseCase
-from application.usecases.save_staff_file import SaveStaffFileUseCase
-from infrastructure.repositories.user_repository import UserRepositoryMongo
+from quyca.application.usecases.process_staff_file import ProcessStaffFileUseCase
+from quyca.application.usecases.save_staff_file import SaveStaffFileUseCase
+from quyca.infrastructure.repositories.user_repository import UserRepositoryMongo
 from werkzeug.datastructures import FileStorage
 
 

--- a/quyca/domain/services/user_service.py
+++ b/quyca/domain/services/user_service.py
@@ -1,10 +1,10 @@
 import hashlib
 import string, random, time
 from typing import List, Any
-from domain.models.user_model import User
-from domain.repositories.user_crud_repository_interface import IUserCrudRepository
-from domain.exceptions.not_entity_exception import NotEntityException
-from infrastructure.notifications.staff_notification import StaffNotification
+from quyca.domain.models.user_model import User
+from quyca.domain.repositories.user_crud_repository_interface import IUserCrudRepository
+from quyca.domain.exceptions.not_entity_exception import NotEntityException
+from quyca.infrastructure.notifications.staff_notification import StaffNotification
 
 """
 Application service for admin user management (create, list, toggle, reset, edit).

--- a/quyca/domain/validators/ciarp_validator.py
+++ b/quyca/domain/validators/ciarp_validator.py
@@ -1,14 +1,14 @@
 from typing import List, Dict, Any, Tuple
 import pandas as pd
-from domain.models.staff_report_model import StaffReport
-from domain.validators.required_fields_validator_ciarp import RequiredFieldsCiarpValidator
-from domain.validators.document_validator import DocumentValidator
-from domain.validators.base_validator import BaseValidator
-from domain.validators.year_validator import YearValidator
-from domain.validators.language_validator import LanguageValidator
-from domain.validators.country_validator import CountryValidator
-from domain.validators.unit_validator import UnitValidator
-from domain.validators.error_grouper import ErrorGrouper
+from quyca.domain.models.staff_report_model import StaffReport
+from quyca.domain.validators.required_fields_validator_ciarp import RequiredFieldsCiarpValidator
+from quyca.domain.validators.document_validator import DocumentValidator
+from quyca.domain.validators.base_validator import BaseValidator
+from quyca.domain.validators.year_validator import YearValidator
+from quyca.domain.validators.language_validator import LanguageValidator
+from quyca.domain.validators.country_validator import CountryValidator
+from quyca.domain.validators.unit_validator import UnitValidator
+from quyca.domain.validators.error_grouper import ErrorGrouper
 
 EXTRA_ALLOWED = {"estado_de_validación", "observación"}
 

--- a/quyca/domain/validators/country_validator.py
+++ b/quyca/domain/validators/country_validator.py
@@ -1,6 +1,6 @@
 import re
 from typing import List, Dict, Any
-from domain.validators.base_validator import BaseValidator
+from quyca.domain.validators.base_validator import BaseValidator
 
 COUNTRY_RE = re.compile(r"^[A-z]{2}$")
 

--- a/quyca/domain/validators/language_validator.py
+++ b/quyca/domain/validators/language_validator.py
@@ -1,6 +1,6 @@
 import re
 from typing import List, Dict, Any
-from domain.validators.base_validator import BaseValidator
+from quyca.domain.validators.base_validator import BaseValidator
 
 LANG_RE = re.compile(r"^[a-z]{2}$")
 

--- a/quyca/domain/validators/required_fields_validator_ciarp.py
+++ b/quyca/domain/validators/required_fields_validator_ciarp.py
@@ -1,5 +1,5 @@
 from typing import List, Dict, Any
-from domain.validators.base_validator import BaseValidator
+from quyca.domain.validators.base_validator import BaseValidator
 
 REQUIRED_FIELDS_CIARP = [
     "código_unidad_académica",

--- a/quyca/domain/validators/staff_validator.py
+++ b/quyca/domain/validators/staff_validator.py
@@ -1,6 +1,6 @@
 from typing import List, Dict, Any, Tuple
 from .required_fields_validator import RequiredFieldsValidator
-from domain.models.staff_report_model import StaffReport
+from quyca.domain.models.staff_report_model import StaffReport
 from .document_validator import DocumentValidator
 from .academic_validator import AcademicValidator
 from .name_validator import NameValidator

--- a/quyca/infrastructure/annotators/annotator.py
+++ b/quyca/infrastructure/annotators/annotator.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from domain.models.staff_report_model import StaffReport
+from quyca.domain.models.staff_report_model import StaffReport
 
 
 class Annotator:

--- a/quyca/infrastructure/container.py
+++ b/quyca/infrastructure/container.py
@@ -1,16 +1,16 @@
 from typing import Tuple
-from infrastructure.repositories.pdf_repository import PDFRepository
-from infrastructure.repositories.gmail_repository import GmailRepository
-from infrastructure.repositories.google_drive_repository import GoogleDriveRepository
-from infrastructure.repositories.file_repository import FileRepository
-from infrastructure.notifications.staff_notification import StaffNotification
-from application.usecases.process_staff_file import ProcessStaffFileUseCase
-from application.usecases.process_ciarp_file import ProcessCiarpFileUseCase
-from application.usecases.save_staff_file import SaveStaffFileUseCase
-from application.usecases.save_ciarp_file import SaveCiarpFileUseCase
-from domain.services.staff_report_service import StaffReportService
-from domain.services.ciarp_report_service import CiarpReportService
-from infrastructure.repositories.user_repository import UserRepositoryMongo
+from quyca.infrastructure.repositories.pdf_repository import PDFRepository
+from quyca.infrastructure.repositories.gmail_repository import GmailRepository
+from quyca.infrastructure.repositories.google_drive_repository import GoogleDriveRepository
+from quyca.infrastructure.repositories.file_repository import FileRepository
+from quyca.infrastructure.notifications.staff_notification import StaffNotification
+from quyca.application.usecases.process_staff_file import ProcessStaffFileUseCase
+from quyca.application.usecases.process_ciarp_file import ProcessCiarpFileUseCase
+from quyca.application.usecases.save_staff_file import SaveStaffFileUseCase
+from quyca.application.usecases.save_ciarp_file import SaveCiarpFileUseCase
+from quyca.domain.services.staff_report_service import StaffReportService
+from quyca.domain.services.ciarp_report_service import CiarpReportService
+from quyca.infrastructure.repositories.user_repository import UserRepositoryMongo
 
 """
 DI composer for Staff: builds infrastructure, use cases and service.

--- a/quyca/infrastructure/elasticsearch.py
+++ b/quyca/infrastructure/elasticsearch.py
@@ -1,6 +1,6 @@
 from elasticsearch import Elasticsearch, __version__ as es_version
 
-from config import settings
+from quyca.config import settings
 
 es_database: Elasticsearch | None = None
 if es_version[0] < 8:

--- a/quyca/infrastructure/generators/affiliation_generator.py
+++ b/quyca/infrastructure/generators/affiliation_generator.py
@@ -2,7 +2,7 @@ from typing import Generator
 
 from pymongo.command_cursor import CommandCursor
 
-from domain.models.affiliation_model import Affiliation
+from quyca.domain.models.affiliation_model import Affiliation
 
 
 def get(cursor: CommandCursor) -> Generator["Affiliation", None, None]:

--- a/quyca/infrastructure/generators/news_generator.py
+++ b/quyca/infrastructure/generators/news_generator.py
@@ -1,6 +1,6 @@
 from typing import Generator
 from pymongo.command_cursor import CommandCursor
-from domain.models.news_model import News
+from quyca.domain.models.news_model import News
 
 
 def get(cursor: CommandCursor) -> Generator:

--- a/quyca/infrastructure/generators/patent_generator.py
+++ b/quyca/infrastructure/generators/patent_generator.py
@@ -2,7 +2,7 @@ from typing import Generator
 
 from pymongo.command_cursor import CommandCursor
 
-from domain.models.patent_model import Patent
+from quyca.domain.models.patent_model import Patent
 
 
 def get(cursor: CommandCursor) -> Generator:

--- a/quyca/infrastructure/generators/person_generator.py
+++ b/quyca/infrastructure/generators/person_generator.py
@@ -2,7 +2,7 @@ from typing import Generator
 
 from pymongo.command_cursor import CommandCursor
 
-from domain.models.person_model import Person
+from quyca.domain.models.person_model import Person
 
 
 def get(cursor: CommandCursor) -> Generator:

--- a/quyca/infrastructure/generators/project_generator.py
+++ b/quyca/infrastructure/generators/project_generator.py
@@ -2,7 +2,7 @@ from typing import Generator
 
 from pymongo.command_cursor import CommandCursor
 
-from domain.models.project_model import Project
+from quyca.domain.models.project_model import Project
 
 
 def get(cursor: CommandCursor) -> Generator:

--- a/quyca/infrastructure/generators/source_generator.py
+++ b/quyca/infrastructure/generators/source_generator.py
@@ -2,7 +2,7 @@ from typing import Generator
 
 from pymongo.command_cursor import CommandCursor
 
-from domain.models.source_model import Source
+from quyca.domain.models.source_model import Source
 
 
 def get(cursor: CommandCursor) -> Generator:

--- a/quyca/infrastructure/notifications/staff_notification.py
+++ b/quyca/infrastructure/notifications/staff_notification.py
@@ -1,7 +1,7 @@
 from typing import Any
-from infrastructure.repositories.gmail_repository import GmailRepository
-from infrastructure.email_templates.staff_report_templates import build_email_template
-from domain.models.staff_report_model import StaffReport
+from quyca.infrastructure.repositories.gmail_repository import GmailRepository
+from quyca.infrastructure.email_templates.staff_report_templates import build_email_template
+from quyca.domain.models.staff_report_model import StaffReport
 
 
 class StaffNotification:

--- a/quyca/infrastructure/repositories/affiliation_repository.py
+++ b/quyca/infrastructure/repositories/affiliation_repository.py
@@ -1,13 +1,13 @@
 from typing import Any, Generator, Tuple
 
 
-from domain.models.base_model import QueryParams
-from domain.constants.institutions import institutions_list
-from domain.models.affiliation_model import Affiliation
-from infrastructure.repositories import base_repository
-from infrastructure.mongo import database
-from infrastructure.repositories.base_repository import set_project
-from domain.exceptions.not_entity_exception import NotEntityException
+from quyca.domain.models.base_model import QueryParams
+from quyca.domain.constants.institutions import institutions_list
+from quyca.domain.models.affiliation_model import Affiliation
+from quyca.infrastructure.repositories import base_repository
+from quyca.infrastructure.mongo import database
+from quyca.infrastructure.repositories.base_repository import set_project
+from quyca.domain.exceptions.not_entity_exception import NotEntityException
 from quyca.infrastructure.generators import affiliation_generator
 
 

--- a/quyca/infrastructure/repositories/file_repository.py
+++ b/quyca/infrastructure/repositories/file_repository.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any
 from zoneinfo import ZoneInfo
 from flask import current_app
-from infrastructure.repositories.google_drive_repository import GoogleDriveRepository
+from quyca.infrastructure.repositories.google_drive_repository import GoogleDriveRepository
 from werkzeug.datastructures import FileStorage
 
 

--- a/quyca/infrastructure/repositories/news_repository.py
+++ b/quyca/infrastructure/repositories/news_repository.py
@@ -1,8 +1,8 @@
-from infrastructure.mongo import database as db
-from infrastructure.generators import news_generator
-from infrastructure.repositories import base_repository
+from quyca.infrastructure.mongo import database as db
+from quyca.infrastructure.generators import news_generator
+from quyca.infrastructure.repositories import base_repository
 from typing import Generator, Optional, Set, Iterable, Any
-from domain.models.base_model import QueryParams
+from quyca.domain.models.base_model import QueryParams
 
 
 def cc_from_person(person_id: str) -> Optional[str]:

--- a/quyca/infrastructure/repositories/pdf_repository.py
+++ b/quyca/infrastructure/repositories/pdf_repository.py
@@ -3,7 +3,7 @@ from xhtml2pdf import pisa
 from datetime import datetime
 from typing import List, Dict, Any
 from zoneinfo import ZoneInfo
-from domain.repositories.pdf_repository_interface import IPDFRepository
+from quyca.domain.repositories.pdf_repository_interface import IPDFRepository
 
 
 """

--- a/quyca/infrastructure/repositories/source_repository.py
+++ b/quyca/infrastructure/repositories/source_repository.py
@@ -1,11 +1,11 @@
 from typing import Any, Generator, Tuple
 from bson import ObjectId
 
-from infrastructure.mongo import database
-from infrastructure.repositories import base_repository
-from infrastructure.generators import source_generator
-from domain.models.source_model import Source
-from domain.exceptions.not_entity_exception import NotEntityException
+from quyca.infrastructure.mongo import database
+from quyca.infrastructure.repositories import base_repository
+from quyca.infrastructure.generators import source_generator
+from quyca.domain.models.source_model import Source
+from quyca.domain.exceptions.not_entity_exception import NotEntityException
 from quyca.domain.constants.source_types import NORMALIZED_TYPE_MAPPING, normalize_source_type
 from quyca.domain.models.base_model import QueryParams, Topic
 

--- a/quyca/infrastructure/repositories/staff_repository.py
+++ b/quyca/infrastructure/repositories/staff_repository.py
@@ -1,5 +1,5 @@
 from typing import Any, Optional
-from domain.repositories.staff_repository_interface import IStaffRepository
+from quyca.domain.repositories.staff_repository_interface import IStaffRepository
 from pymongo.database import Database
 
 

--- a/quyca/infrastructure/repositories/user_crud_repository.py
+++ b/quyca/infrastructure/repositories/user_crud_repository.py
@@ -1,8 +1,8 @@
 from typing import List, Optional, Dict, Any
-from domain.models.user_model import User
-from infrastructure.mongo import impactu_database
-from domain.repositories.user_crud_repository_interface import IUserCrudRepository
-from domain.exceptions.not_entity_exception import NotEntityException
+from quyca.domain.models.user_model import User
+from quyca.infrastructure.mongo import impactu_database
+from quyca.domain.repositories.user_crud_repository_interface import IUserCrudRepository
+from quyca.domain.exceptions.not_entity_exception import NotEntityException
 
 
 class UserCrudRepository(IUserCrudRepository):

--- a/quyca/infrastructure/repositories/user_repository.py
+++ b/quyca/infrastructure/repositories/user_repository.py
@@ -1,8 +1,8 @@
 import hashlib
-from domain.models.user_model import User
-from infrastructure.mongo import impactu_database
-from domain.exceptions.not_entity_exception import NotEntityException
-from domain.repositories.user_repository_interface import IUserRepository
+from quyca.domain.models.user_model import User
+from quyca.infrastructure.mongo import impactu_database
+from quyca.domain.exceptions.not_entity_exception import NotEntityException
+from quyca.domain.repositories.user_repository_interface import IUserRepository
 
 """
 MongoDB repository for login + token management.


### PR DESCRIPTION
### Refactor import paths to align with Docker and package structure changes

This change was required after updating docker-compose to prevent overwriting the static directory where the API documentation generated by ApiDocJS is stored and served.

By avoiding the volume override, the application now relies on the real package layout inside the container. As a result, implicit imports such as application.* were no longer resolvable during module-based execution (e.g. pytest), exposing inconsistencies in the import paths.

#### What was done:

- Updated import statements to use the explicit root package quyca.*.
- Refactored imports across routes, use cases, domain services, and infrastructure layers.
- Aligned the import structure with Python packaging best practices and Docker execution context.
- Fixed test execution issues caused by incorrect module resolution.