### PR TITLE
Fix validation errors & types in Person model

### DIFF
--- a/quyca/domain/models/person_model.py
+++ b/quyca/domain/models/person_model.py
@@ -55,7 +55,7 @@ class Degree(BaseModel):
 
 class Institution(BaseModel):
     id: str | None
-    country_code: str | None
+    country_code: Optional[str] = None
     country_id: Optional[str] = None
     display_name: str | None
     lineage: list[str] | None = Field(default_factory=list)

--- a/quyca/domain/models/person_model.py
+++ b/quyca/domain/models/person_model.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 from bson import ObjectId
 from pydantic import BaseModel, Field, field_validator, model_validator
 from quyca.domain.models.base_model import (
@@ -69,6 +69,13 @@ class RelatedWork(BaseModel):
     provenance: str | None
     source: str | None
     year: int | None = None
+
+    @field_validator("institutions", mode="before")
+    @classmethod
+    def clean_institutions(cls: type, value: Any) -> Any:
+        if not value:
+            return []
+        return [inst for inst in value if inst.get("id") and inst.get("type") is not None]
 
 
 class Person(BaseModel):

--- a/quyca/domain/models/person_model.py
+++ b/quyca/domain/models/person_model.py
@@ -54,13 +54,13 @@ class Degree(BaseModel):
 
 
 class Institution(BaseModel):
-    id: str | None
+    id: Optional[str] = None
     country_code: Optional[str] = None
     country_id: Optional[str] = None
-    display_name: str | None
-    lineage: list[str] | None = Field(default_factory=list)
-    ror: str | None
-    type: str | None
+    display_name: Optional[str] = None
+    lineage: list[str] = Field(default_factory=list)
+    ror: Optional[str] = None
+    type: Optional[str] = None
 
 
 class RelatedWork(BaseModel):
@@ -72,10 +72,20 @@ class RelatedWork(BaseModel):
 
     @field_validator("institutions", mode="before")
     @classmethod
-    def clean_institutions(cls: type, value: Any) -> Any:
+    def clean_institutions(cls, value: Any) -> list:
         if not value:
             return []
-        return [inst for inst in value if inst.get("id") and inst.get("type") is not None]
+
+        cleaned = []
+        for inst in value:
+            if not isinstance(inst, dict):
+                continue
+            if inst.get("type") is None:
+                continue
+
+            cleaned.append(inst)
+
+        return cleaned
 
 
 class Person(BaseModel):

--- a/quyca/domain/models/work_model.py
+++ b/quyca/domain/models/work_model.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from bson import ObjectId
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from quyca.domain.models.base_model import (
     PyObjectId,
@@ -146,3 +146,10 @@ class Work(BaseModel):
 
     class Config:
         json_encoders = {ObjectId: str}
+
+    @field_validator("date_published", mode="before")
+    @classmethod
+    def empty_string_to_none(cls: type, value: str) -> Any:
+        if value in ("", None):
+            return None
+        return value

--- a/quyca/domain/services/base_service.py
+++ b/quyca/domain/services/base_service.py
@@ -56,7 +56,7 @@ def set_authors_external_ids(workable: Union[Work, Patent, Project]) -> None:
 
     for author in workable.authors:
         if author.id:
-            author.external_ids = person_repository.get_person_by_id(str(author.id)).external_ids
+            author.external_ids = person_repository.get_person_external_ids(str(author.id))
 
 
 def limit_authors(workable: Union[Work, Patent, Project], limit: int = 10) -> None:

--- a/quyca/infrastructure/repositories/person_repository.py
+++ b/quyca/infrastructure/repositories/person_repository.py
@@ -1,8 +1,8 @@
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Any, Dict, Generator, List, Mapping, Sequence, Tuple
 from bson import ObjectId
 
 from quyca.infrastructure.generators import person_generator
-from quyca.domain.models.base_model import QueryParams
+from quyca.domain.models.base_model import ExternalId, QueryParams
 from quyca.infrastructure.repositories import base_repository
 from quyca.domain.exceptions.not_entity_exception import NotEntityException
 from quyca.domain.models.person_model import Person
@@ -139,3 +139,20 @@ def search_persons(query_params: QueryParams, pipeline_params: dict | None = Non
     ]
     total_results = next(database["person"].aggregate(count_pipeline), {"total_results": 0})["total_results"]
     return person_generator.get(persons), total_results
+
+
+def get_person_external_ids(person_id: str) -> list[ExternalId]:
+    match = {"$match": {"_id": person_id}}
+
+    pipeline: Sequence[Mapping[str, Any]] = [
+        match,
+        {"$project": {"external_ids": 1}},
+    ]
+
+    cursor = database["person"].aggregate(pipeline)
+    data = next(cursor, None)
+
+    if not data:
+        return []
+
+    return [ExternalId(**eid) for eid in data.get("external_ids", [])]


### PR DESCRIPTION
This pull request fixes a validation error caused by empty string values in the database and improves performance and robustness when fetching `external_ids` for authors.

---

## 🐛 Bug Fix: `date_published` validation error

Some `Work` documents contain invalid values like:

```json
{ "date_published": "" }
```

This caused `Pydantic` to fail when parsing `date_published` as an `int.`

### ✅ Solution

A defensive field_validator was added to the Work model to normalize empty strings into None before type validation:

```python
@field_validator("date_published", mode="before")
@classmethod
def empty_string_to_none(cls, value):
    if value in ("", None):
        return None
    return value
```

## 🚀 Improvement: Dedicated repository method for external_ids

Previously, the full `Person` aggregate was loaded when only `external_ids` were needed.
This caused unnecessary `validation` of deep structures like `related_works.`

#### ✅ Solution

- A new repository method was introduced to fetch only the required data:
- Added `get_person_external_ids(...)` to `person_repository`
- Updated the service layer to use this method instead of loading the full `Person` model