### PR TITLE
feat: add /info/quality endpoint with data quality metrics per collection

### DIFF
--- a/quyca/application/routes/app/info_app_router.py
+++ b/quyca/application/routes/app/info_app_router.py
@@ -18,3 +18,13 @@ def get_info() -> Response | Tuple[Response, int]:
     except Exception as e:
         capture_exception(e)
         return jsonify({"error": str(e)}), 400
+
+
+@info_app_router.route("/info/quality", methods=["GET"])
+def get_info_quality() -> Response | Tuple[Response, int]:
+    try:
+        data = info_service.get_works_quality_metrics()
+        return jsonify(data)
+    except Exception as e:
+        capture_exception(e)
+        return jsonify({"error": str(e)}), 400

--- a/quyca/domain/constants/staff_field_values.py
+++ b/quyca/domain/constants/staff_field_values.py
@@ -66,7 +66,6 @@ ACADEMIC_LEVEL_MAP: dict[str, str] = {
     # técnico
     "tecnico": "técnico",
     "técnico": "técnico",
-    "tec": "técnico",
     # tecnológico
     "tecnologico": "tecnológico",
     "tecnológico": "tecnológico",
@@ -288,10 +287,12 @@ SEX_MAP: dict[str, str] = {
     "f": "mujer",
     # intersexual
     "intersexual": "intersexual",
+    "i": "intersexual",
     # no binario
     "no binario": "no binario",
     "nobinario": "no binario",
     "no-binario": "no binario",
     "non binary": "no binario",
     "non-binary": "no binario",
+    "nb": "no binario",
 }

--- a/quyca/domain/constants/staff_field_values.py
+++ b/quyca/domain/constants/staff_field_values.py
@@ -274,6 +274,7 @@ SEX = {
     "hombre",
     "mujer",
     "intersexual",
+    "no binario",
 }
 
 SEX_MAP: dict[str, str] = {
@@ -287,4 +288,10 @@ SEX_MAP: dict[str, str] = {
     "f": "mujer",
     # intersexual
     "intersexual": "intersexual",
+    # no binario
+    "no binario": "no binario",
+    "nobinario": "no binario",
+    "no-binario": "no binario",
+    "non binary": "no binario",
+    "non-binary": "no binario",
 }

--- a/quyca/domain/normalizers/staff_normalizer_service.py
+++ b/quyca/domain/normalizers/staff_normalizer_service.py
@@ -12,6 +12,7 @@ Two-phase normalization:
 from __future__ import annotations
 
 import unicodedata
+import re
 from datetime import date, datetime, timezone
 from typing import Any
 
@@ -40,6 +41,8 @@ _FIELD_MAPS: dict[str, dict[str, str]] = {
 }
 
 _DATE_FIELDS = ["fecha_nacimiento", "fecha_inicial_vinculación", "fecha_final_vinculación"]
+_NUMERIC_TEXT_FIELDS = {"identificación"}
+_INTEGER_TEXT_RE = re.compile(r"^[0-9]+(?:\.0+)?$")
 
 _UNKNOWN_VALUE = "desconocido"
 _UNKNOWN_ALIASES = {
@@ -121,6 +124,11 @@ class StaffNormalizerService:
             if field in df.columns:
                 df[field] = df[field].apply(self._parse_date)
 
+        # Convert numeric-looking identifiers/codes to real numeric values when safe.
+        for field in _NUMERIC_TEXT_FIELDS:
+            if field in df.columns:
+                df[field] = df[field].apply(self._coerce_numeric_scalar)
+
         return df
 
     @staticmethod
@@ -138,6 +146,30 @@ class StaffNormalizerService:
                 return parsed_date.strftime("%d/%m/%Y")
             except Exception:
                 return value
+        return value
+
+    @staticmethod
+    def _coerce_numeric_scalar(value: Any) -> Any:
+        """Convert safe numeric-looking values to ints so Excel writes them as numeric cells."""
+        if pd.isna(value):
+            return value
+
+        if isinstance(value, bool):
+            return value
+
+        if isinstance(value, (int, float)):
+            if isinstance(value, float) and not value.is_integer():
+                return value
+            return int(value)
+
+        if isinstance(value, str):
+            stripped = value.strip()
+            if _INTEGER_TEXT_RE.match(stripped):
+                integer_part = stripped.split(".", 1)[0]
+                if len(integer_part) > 1 and integer_part.startswith("0"):
+                    return value
+                return int(float(stripped))
+
         return value
 
     # ------------------------------------------------------------------

--- a/quyca/domain/services/info_service.py
+++ b/quyca/domain/services/info_service.py
@@ -18,3 +18,12 @@ def get_info() -> dict:
         "total_open_access": info_repository.get_open_access_count(),
         "total_sources": info_repository.get_entity_count("sources"),
     }
+
+
+def get_works_quality_metrics() -> dict:
+    return {
+        "works_collection": info_repository.get_works_quality_metrics(),
+        "person_collection": info_repository.get_person_quality_metrics(),
+        "affiliations_collection": info_repository.get_affiliations_quality_metrics(),
+        "sources_collection": info_repository.get_sources_quality_metrics(),
+    }

--- a/quyca/domain/validators/ciarp_validator.py
+++ b/quyca/domain/validators/ciarp_validator.py
@@ -1,3 +1,4 @@
+import re
 import unicodedata
 from typing import List, Dict, Any, Tuple
 import pandas as pd
@@ -43,6 +44,33 @@ def _normalize(s: str) -> str:
     return unicodedata.normalize("NFD", s).encode("ascii", "ignore").decode("ascii").strip().lower()
 
 
+_INTEGER_TEXT_RE = re.compile(r"^[0-9]+(?:\.0+)?$")
+
+
+def _coerce_integer_like(value: Any) -> Any:
+    """Convert safe integer-like values stored as text or floats to ints."""
+    if pd.isna(value):
+        return value
+
+    if isinstance(value, bool):
+        return value
+
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and not value.is_integer():
+            return value
+        return int(value)
+
+    if isinstance(value, str):
+        stripped = value.strip()
+        if _INTEGER_TEXT_RE.match(stripped):
+            integer_part = stripped.split(".", 1)[0]
+            if len(integer_part) > 1 and integer_part.startswith("0"):
+                return value
+            return int(float(stripped))
+
+    return value
+
+
 _NORMALIZED_REQUIRED = {_normalize(c): c for c in REQUIRED_COLUMNS}
 _NORMALIZED_EXTRA_ALLOWED = {_normalize(c) for c in EXTRA_ALLOWED}
 
@@ -79,16 +107,9 @@ class CiarpValidator:
         normalized_usecols = {_normalize(c): c for c in usecols}
 
         missing = [c for c in REQUIRED_COLUMNS if _normalize(c) not in normalized_usecols]
-        extra = [
-            original
-            for norm, original in normalized_usecols.items()
-            if norm not in _NORMALIZED_REQUIRED and norm not in _NORMALIZED_EXTRA_ALLOWED
-        ]
 
         if missing:
             errors.append(f"Columnas faltantes: {', '.join(missing)}")
-        if extra:
-            errors.append(f"Columnas no permitidas: {', '.join(extra)}")
 
         # Return usecols using canonical names from REQUIRED_COLUMNS where possible
         usecols = [
@@ -144,6 +165,10 @@ class CiarpValidator:
         df = df.dropna(how="all").reset_index(drop=True)
         df = df.map(lambda v: v.strip() if isinstance(v, str) else v)
         df = df.apply(lambda x: str(int(x)) if isinstance(x, float) and x.is_integer() else x)
+
+        for field in ["identificación", "año"]:
+            if field in df.columns:
+                df[field] = df[field].apply(_coerce_integer_like)
 
         for idx, row in df.iterrows():
             result = CiarpValidator.validate_row(row.to_dict(), idx)

--- a/quyca/domain/validators/document_validator.py
+++ b/quyca/domain/validators/document_validator.py
@@ -1,4 +1,5 @@
 import re
+import unicodedata
 from typing import List, Dict, Any
 from .base_validator import BaseValidator
 from quyca.domain.constants.staff_field_values import DOCUMENT_TYPES
@@ -6,6 +7,17 @@ from quyca.domain.constants.staff_field_values import DOCUMENT_TYPES
 PASSPORT_RE = re.compile(r"^[A-Za-z0-9]+$")
 
 _NUMERIC_ID_TYPES = {"cédula de ciudadanía", "cédula de extranjería"}
+
+_INTEGER_TEXT_RE = re.compile(r"^[0-9]+(?:\.0+)?$")
+
+
+def _is_numeric_identification(value: Any) -> bool:
+    """Accept integer-like values even when Excel stored them as text or float strings."""
+    if BaseValidator.is_empty(value):
+        return False
+
+    normalized = unicodedata.normalize("NFKC", str(value)).strip()
+    return bool(_INTEGER_TEXT_RE.match(normalized))
 
 
 class DocumentValidator:
@@ -35,7 +47,7 @@ class DocumentValidator:
             if not BaseValidator.is_empty(identificacion):
                 id_str = str(identificacion).strip()
 
-                if tnorm in _NUMERIC_ID_TYPES and not id_str.isdigit():
+                if tnorm in _NUMERIC_ID_TYPES and not _is_numeric_identification(identificacion):
                     errors.append(
                         {
                             "fila": index,

--- a/quyca/domain/validators/year_validator.py
+++ b/quyca/domain/validators/year_validator.py
@@ -1,5 +1,9 @@
 from datetime import datetime
+import re
 from typing import Any, Dict, Optional
+
+
+_INTEGER_TEXT_RE = re.compile(r"^[0-9]+(?:\.0+)?$")
 
 
 class YearValidator:
@@ -12,7 +16,14 @@ class YearValidator:
         if value is None or str(value).strip() == "":
             return None
         try:
-            year = int(value)
+            if isinstance(value, str):
+                stripped = value.strip()
+                if _INTEGER_TEXT_RE.match(stripped):
+                    year = int(float(stripped))
+                else:
+                    year = int(stripped)
+            else:
+                year = int(value)
             current_year = datetime.now().year
             if year > current_year:
                 return {

--- a/quyca/infrastructure/repositories/info_repository.py
+++ b/quyca/infrastructure/repositories/info_repository.py
@@ -135,7 +135,9 @@ def _compute_works_quality_metrics() -> dict:
         "without_impactu_normalization_skipped",
         "without_impactu_by_source",
     )
-    metrics: dict[str, Any] = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
+    metrics: dict[str, Any] = {
+        key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar
+    }
 
     totals_provenance: dict[str, int] = {}
     for item in result.get("provenance_breakdown", []):
@@ -243,7 +245,9 @@ def _compute_person_quality_metrics() -> dict:
     result: dict[str, Any] = next(database["person"].aggregate(pipeline, allowDiskUse=True), {})
 
     non_scalar = ("provenance_breakdown", "external_ids_breakdown", "with_cedula_scienti", "with_cedula_staff")
-    metrics: dict[str, Any] = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
+    metrics: dict[str, Any] = {
+        key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar
+    }
 
     totals_provenance: dict[str, int] = {}
     for item in result.get("provenance_breakdown", []):
@@ -353,7 +357,9 @@ def _compute_affiliations_quality_metrics() -> dict:
     result: dict[str, Any] = next(database["affiliations"].aggregate(pipeline, allowDiskUse=True), {})
 
     non_scalar = ("provenance_breakdown", "types_breakdown", "external_ids_breakdown")
-    metrics: dict[str, Any] = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
+    metrics: dict[str, Any] = {
+        key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar
+    }
 
     totals_provenance: dict[str, int] = {}
     for item in result.get("provenance_breakdown", []):
@@ -462,7 +468,9 @@ def _compute_sources_quality_metrics() -> dict:
         "provenance_breakdown",
         "external_ids_breakdown",
     )
-    metrics: dict[str, Any] = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
+    metrics: dict[str, Any] = {
+        key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar
+    }
 
     totals_provenance: dict[str, int] = {}
     for item in result.get("provenance_breakdown", []):

--- a/quyca/infrastructure/repositories/info_repository.py
+++ b/quyca/infrastructure/repositories/info_repository.py
@@ -1,13 +1,14 @@
 from quyca.domain.constants.institutions import institutions_list
 from quyca.infrastructure.mongo import database
 
+_works_quality_cache: dict | None = None
+_person_quality_cache: dict | None = None
+
 
 def get_last_db_update() -> int:
     doc = database["log"].find_one(sort=[("time", -1)], projection={"time": 1})
-
     if doc:
         return int(doc["time"])
-
     return 0
 
 
@@ -25,3 +26,467 @@ def get_open_access_count() -> int:
 
 def get_news_count() -> int:
     return database["news_urls_collection"].estimated_document_count()
+
+
+def get_works_quality_metrics() -> dict:
+    global _works_quality_cache
+    if _works_quality_cache is not None:
+        return _works_quality_cache
+    _works_quality_cache = _compute_works_quality_metrics()
+    return _works_quality_cache
+
+
+def invalidate_works_quality_cache() -> None:
+    global _works_quality_cache
+    _works_quality_cache = None
+
+
+def _compute_works_quality_metrics() -> dict:
+    ALL_SOURCES = ["ciarp", "dspace", "minciencias", "openalex", "scholar", "scienti"]
+    MAIN_SOURCES = ["scienti", "minciencias", "openalex"]
+    pipeline = [
+        {
+            "$facet": {
+                "with_doi": [{"$match": {"doi": {"$nin": [None, ""]}}}, {"$count": "n"}],
+                "with_abstract": [{"$match": {"abstracts.0": {"$exists": True}}}, {"$count": "n"}],
+                "with_primary_topic": [{"$match": {"primary_topic": {"$nin": [None, {}]}}}, {"$count": "n"}],
+                "with_year_published": [{"$match": {"year_published": {"$ne": None}}}, {"$count": "n"}],
+                "with_source": [{"$match": {"source.id": {"$nin": [None, ""]}}}, {"$count": "n"}],
+                "open_access_status_known": [
+                    {"$match": {"open_access.is_open_access": {"$ne": None}}},
+                    {"$count": "n"},
+                ],
+                "with_apc_paid": [{"$match": {"apc.paid.value": {"$ne": None}}}, {"$count": "n"}],
+                "with_citations": [{"$match": {"citations_count_openalex": {"$gt": 0}}}, {"$count": "n"}],
+                "with_ranking_minciencias": [
+                    {"$match": {"ranking": {"$elemMatch": {"source": "minciencias"}}}},
+                    {"$count": "n"},
+                ],
+                "with_research_groups": [{"$match": {"groups.0": {"$exists": True}}}, {"$count": "n"}],
+                "provenance_breakdown": [
+                    {"$project": {"combo": {"$setIntersection": [{"$ifNull": ["$updated.source", []]}, ALL_SOURCES]}}},
+                    {"$group": {"_id": "$combo", "count": {"$sum": 1}}},
+                ],
+                "impactu_types": [
+                    {"$unwind": "$types"},
+                    {"$match": {"types.source": "impactu"}},
+                    {"$group": {"_id": "$types.type", "count": {"$sum": 1}}},
+                    {"$sort": {"count": -1}},
+                ],
+                "without_impactu_no_types": [
+                    {"$match": {"$or": [{"types": {"$exists": False}}, {"types": []}]}},
+                    {"$count": "n"},
+                ],
+                "without_impactu_normalization_skipped": [
+                    {
+                        "$match": {
+                            "$and": [
+                                {"types": {"$not": {"$elemMatch": {"source": "impactu"}}}},
+                                {
+                                    "$expr": {
+                                        "$gt": [
+                                            {
+                                                "$size": {
+                                                    "$filter": {
+                                                        "input": {"$ifNull": ["$types", []]},
+                                                        "as": "t",
+                                                        "cond": {"$in": ["$$t.source", MAIN_SOURCES]},
+                                                    }
+                                                }
+                                            },
+                                            0,
+                                        ]
+                                    }
+                                },
+                            ]
+                        }
+                    },
+                    {"$count": "n"},
+                ],
+                "without_impactu_by_source": [
+                    {
+                        "$match": {
+                            "$and": [
+                                {"types": {"$not": {"$elemMatch": {"source": "impactu"}}}},
+                                {"types.0": {"$exists": True}},
+                            ]
+                        }
+                    },
+                    {
+                        "$project": {
+                            "sources": {"$setUnion": [{"$map": {"input": "$types", "as": "t", "in": "$$t.source"}}, []]}
+                        }
+                    },
+                    {"$unwind": "$sources"},
+                    {"$group": {"_id": "$sources", "count": {"$sum": 1}}},
+                    {"$sort": {"count": -1}},
+                ],
+            }
+        }
+    ]
+
+    result = next(database["works"].aggregate(pipeline, allowDiskUse=True), {})
+
+    non_scalar = (
+        "provenance_breakdown",
+        "impactu_types",
+        "without_impactu_no_types",
+        "without_impactu_normalization_skipped",
+        "without_impactu_by_source",
+    )
+    metrics = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
+
+    totals_provenance: dict[str, int] = {}
+    for item in result.get("provenance_breakdown", []):
+        for source in item["_id"]:
+            totals_provenance[source] = totals_provenance.get(source, 0) + item["count"]
+
+    metrics["provenance_breakdown"] = {
+        ("_".join(sorted(item["_id"])) if item["_id"] else "none"): item["count"]
+        for item in result.get("provenance_breakdown", [])
+    }
+    metrics["provenance_breakdown"]["totals_provenance"] = dict(
+        sorted(totals_provenance.items(), key=lambda x: x[1], reverse=True)
+    )
+
+    assigned = sum(item["count"] for item in result.get("impactu_types", []))
+    metrics["total"] = database["works"].estimated_document_count()
+    metrics["types_breakdown"] = {
+        "with_impactu_total": assigned,
+        "without_impactu_total": metrics["total"] - assigned,
+        "impactu": [{"type": item["_id"], "count": item["count"]} for item in result.get("impactu_types", [])],
+        "without_impactu": {
+            "no_types": result.get("without_impactu_no_types", [{}])[0].get("n", 0),
+            "normalization_skipped": result.get("without_impactu_normalization_skipped", [{}])[0].get("n", 0),
+            "by_source": {item["_id"]: item["count"] for item in result.get("without_impactu_by_source", [])},
+        },
+    }
+    return metrics
+
+
+def get_person_quality_metrics() -> dict:
+    global _person_quality_cache
+    if _person_quality_cache is not None:
+        return _person_quality_cache
+    _person_quality_cache = _compute_person_quality_metrics()
+    return _person_quality_cache
+
+
+def invalidate_person_quality_cache() -> None:
+    global _person_quality_cache
+    _person_quality_cache = None
+
+
+def _compute_person_quality_metrics() -> dict:
+    ALL_SOURCES = ["minciencias", "openalex", "orcid", "scholar", "scienti", "staff"]
+    pipeline = [
+        {
+            "$facet": {
+                "with_citations": [{"$match": {"citations_count_openalex": {"$gt": 0}}}, {"$count": "n"}],
+                "with_hindex": [{"$match": {"h_index": {"$gt": 0}}}, {"$count": "n"}],
+                "with_cedula_scienti": [
+                    {
+                        "$match": {
+                            "external_ids": {
+                                "$elemMatch": {
+                                    "source": {"$in": ["Cédula de Ciudadanía", "Cédula de Extranjería", "Passport"]},
+                                    "provenance": "scienti",
+                                }
+                            }
+                        }
+                    },
+                    {"$count": "n"},
+                ],
+                "with_cedula_staff": [
+                    {
+                        "$match": {
+                            "external_ids": {
+                                "$elemMatch": {
+                                    "source": {"$in": ["Cédula de Ciudadanía", "Cédula de Extranjería", "Passport"]},
+                                    "provenance": "staff",
+                                }
+                            }
+                        }
+                    },
+                    {"$count": "n"},
+                ],
+                "provenance_breakdown": [
+                    {"$project": {"combo": {"$setIntersection": [{"$ifNull": ["$updated.source", []]}, ALL_SOURCES]}}},
+                    {"$group": {"_id": "$combo", "count": {"$sum": 1}}},
+                ],
+                "external_ids_breakdown": [
+                    {
+                        "$project": {
+                            "sources": {
+                                "$setUnion": [
+                                    {
+                                        "$map": {
+                                            "input": {"$ifNull": ["$external_ids", []]},
+                                            "as": "e",
+                                            "in": "$$e.source",
+                                        }
+                                    },
+                                    [],
+                                ]
+                            }
+                        }
+                    },
+                    {"$unwind": "$sources"},
+                    {"$group": {"_id": "$sources", "count": {"$sum": 1}}},
+                    {"$sort": {"count": -1}},
+                ],
+            }
+        }
+    ]
+
+    result = next(database["person"].aggregate(pipeline, allowDiskUse=True), {})
+
+    non_scalar = ("provenance_breakdown", "external_ids_breakdown", "with_cedula_scienti", "with_cedula_staff")
+    metrics = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
+
+    totals_provenance: dict[str, int] = {}
+    for item in result.get("provenance_breakdown", []):
+        for source in item["_id"]:
+            totals_provenance[source] = totals_provenance.get(source, 0) + item["count"]
+
+    metrics["provenance_breakdown"] = {
+        ("_".join(sorted(item["_id"])) if item["_id"] else "none"): item["count"]
+        for item in result.get("provenance_breakdown", [])
+    }
+    metrics["provenance_breakdown"]["totals_provenance"] = dict(
+        sorted(totals_provenance.items(), key=lambda x: x[1], reverse=True)
+    )
+
+    metrics["external_ids_breakdown"] = {
+        item["_id"]: item["count"] for item in result.get("external_ids_breakdown", [])
+    }
+
+    cedula_scienti = result.get("with_cedula_scienti", [{}])[0].get("n", 0)
+    cedula_staff = result.get("with_cedula_staff", [{}])[0].get("n", 0)
+    metrics["with_cedula"] = {
+        "total": cedula_scienti + cedula_staff,
+        "scienti": cedula_scienti,
+        "staff": cedula_staff,
+    }
+
+    # Derivados desde datos ya calculados — sin ramas extra en $facet
+    metrics["with_orcid"] = metrics["external_ids_breakdown"].get("orcid", 0)
+    metrics["with_staff"] = metrics["provenance_breakdown"]["totals_provenance"].get("staff", 0)
+    metrics["total"] = database["person"].estimated_document_count()
+    return metrics
+
+
+_affiliations_quality_cache: dict | None = None
+
+
+def get_affiliations_quality_metrics() -> dict:
+    global _affiliations_quality_cache
+    if _affiliations_quality_cache is not None:
+        return _affiliations_quality_cache
+    _affiliations_quality_cache = _compute_affiliations_quality_metrics()
+    return _affiliations_quality_cache
+
+
+def invalidate_affiliations_quality_cache() -> None:
+    global _affiliations_quality_cache
+    _affiliations_quality_cache = None
+
+
+def _compute_affiliations_quality_metrics() -> dict:
+    ALL_SOURCES = ["minciencias", "openalex", "ror", "scienti", "staff", "wikidata"]
+    pipeline = [
+        {
+            "$facet": {
+                "with_country": [{"$match": {"addresses.0": {"$exists": True}}}, {"$count": "n"}],
+                "with_year_established": [{"$match": {"year_established": {"$ne": None}}}, {"$count": "n"}],
+                "with_products": [{"$match": {"products_count": {"$gt": 0}}}, {"$count": "n"}],
+                "with_citations": [{"$match": {"citations_count_openalex": {"$gt": 0}}}, {"$count": "n"}],
+                "with_hindex": [{"$match": {"h_index": {"$gt": 0}}}, {"$count": "n"}],
+                "with_relations": [{"$match": {"relations.0": {"$exists": True}}}, {"$count": "n"}],
+                "colombian": [{"$match": {"addresses": {"$elemMatch": {"country_code": "CO"}}}}, {"$count": "n"}],
+                "research_groups": [
+                    # If ranking.0 exists, it has a Minciencias/Scienti classification — it's always of type group.
+                    {"$match": {"ranking.0": {"$exists": True}}},
+                    {"$count": "n"},
+                ],
+                "provenance_breakdown": [
+                    {"$project": {"combo": {"$setIntersection": [{"$ifNull": ["$updated.source", []]}, ALL_SOURCES]}}},
+                    {"$group": {"_id": "$combo", "count": {"$sum": 1}}},
+                ],
+                "types_breakdown": [
+                    {"$unwind": "$types"},
+                    {
+                        "$match": {
+                            "types.source": {"$in": ["ror", "staff", "minciencias", "scienti"]},
+                            "types.type": {"$nin": ["Funder", "funder"]},
+                        }
+                    },
+                    {"$group": {"_id": {"$toLower": "$types.type"}, "count": {"$sum": 1}}},
+                    {"$sort": {"count": -1}},
+                ],
+                "external_ids_breakdown": [
+                    {
+                        "$project": {
+                            "sources": {
+                                "$setUnion": [
+                                    {
+                                        "$map": {
+                                            "input": {"$ifNull": ["$external_ids", []]},
+                                            "as": "e",
+                                            "in": "$$e.source",
+                                        }
+                                    },
+                                    [],
+                                ]
+                            }
+                        }
+                    },
+                    {"$unwind": "$sources"},
+                    {"$group": {"_id": "$sources", "count": {"$sum": 1}}},
+                    {"$sort": {"count": -1}},
+                ],
+            }
+        }
+    ]
+
+    result = next(database["affiliations"].aggregate(pipeline, allowDiskUse=True), {})
+
+    non_scalar = ("provenance_breakdown", "types_breakdown", "external_ids_breakdown")
+    metrics = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
+
+    totals_provenance: dict[str, int] = {}
+    for item in result.get("provenance_breakdown", []):
+        for source in item["_id"]:
+            totals_provenance[source] = totals_provenance.get(source, 0) + item["count"]
+
+    metrics["provenance_breakdown"] = {
+        ("_".join(sorted(item["_id"])) if item["_id"] else "none"): item["count"]
+        for item in result.get("provenance_breakdown", [])
+    }
+    metrics["provenance_breakdown"]["totals_provenance"] = dict(
+        sorted(totals_provenance.items(), key=lambda x: x[1], reverse=True)
+    )
+    metrics["types_breakdown"] = {item["_id"]: item["count"] for item in result.get("types_breakdown", [])}
+    metrics["external_ids_breakdown"] = {
+        item["_id"]: item["count"] for item in result.get("external_ids_breakdown", [])
+    }
+    metrics["total"] = database["affiliations"].estimated_document_count()
+    return metrics
+
+
+_sources_quality_cache: dict | None = None
+
+
+def get_sources_quality_metrics() -> dict:
+    global _sources_quality_cache
+    if _sources_quality_cache is not None:
+        return _sources_quality_cache
+    _sources_quality_cache = _compute_sources_quality_metrics()
+    return _sources_quality_cache
+
+
+def invalidate_sources_quality_cache() -> None:
+    global _sources_quality_cache
+    _sources_quality_cache = None
+
+
+def _compute_sources_quality_metrics() -> dict:
+    ALL_SOURCES = ["doaj", "openalex", "scienti", "scimago"]
+    pipeline = [
+        {
+            "$facet": {
+                "with_publisher": [{"$match": {"publisher.name": {"$nin": [None, ""]}}}, {"$count": "n"}],
+                "with_apc": [{"$match": {"apc": {"$ne": {}}, "apc.charges": {"$gt": 0}}}, {"$count": "n"}],
+                "with_ranking": [{"$match": {"ranking.0": {"$exists": True}}}, {"$count": "n"}],
+                "with_products": [{"$match": {"products_count": {"$gt": 0}}}, {"$count": "n"}],
+                "with_topics": [{"$match": {"topics.0": {"$exists": True}}}, {"$count": "n"}],
+                "with_licenses": [{"$match": {"licenses.0": {"$exists": True}}}, {"$count": "n"}],
+                "open_access_breakdown": [
+                    {"$match": {"open_access_status": {"$ne": None}}},
+                    {"$group": {"_id": "$open_access_status", "count": {"$sum": 1}}},
+                    {"$sort": {"count": -1}},
+                ],
+                "scimago_quartiles_breakdown": [
+                    {"$match": {"scimago_best_quartile": {"$nin": [None, ""]}}},
+                    {"$group": {"_id": "$scimago_best_quartile", "count": {"$sum": 1}}},
+                    {"$sort": {"count": -1}},
+                ],
+                "source_types_breakdown": [
+                    {"$unwind": "$types"},
+                    {"$match": {"types.source": "openalex"}},
+                    {"$group": {"_id": "$types.type", "count": {"$sum": 1}}},
+                    {"$sort": {"count": -1}},
+                ],
+                "license_type_breakdown": [
+                    {"$unwind": "$licenses"},
+                    {"$group": {"_id": "$licenses.type", "count": {"$sum": 1}}},
+                    {"$sort": {"count": -1}},
+                ],
+                "provenance_breakdown": [
+                    {"$project": {"combo": {"$setIntersection": [{"$ifNull": ["$updated.source", []]}, ALL_SOURCES]}}},
+                    {"$group": {"_id": "$combo", "count": {"$sum": 1}}},
+                ],
+                "external_ids_breakdown": [
+                    {
+                        "$project": {
+                            "sources": {
+                                "$setUnion": [
+                                    {
+                                        "$map": {
+                                            "input": {"$ifNull": ["$external_ids", []]},
+                                            "as": "e",
+                                            "in": "$$e.source",
+                                        }
+                                    },
+                                    [],
+                                ]
+                            }
+                        }
+                    },
+                    {"$unwind": "$sources"},
+                    {"$group": {"_id": "$sources", "count": {"$sum": 1}}},
+                    {"$sort": {"count": -1}},
+                ],
+            }
+        }
+    ]
+
+    result = next(database["sources"].aggregate(pipeline, allowDiskUse=True), {})
+
+    non_scalar = (
+        "open_access_breakdown",
+        "scimago_quartiles_breakdown",
+        "source_types_breakdown",
+        "license_type_breakdown",
+        "provenance_breakdown",
+        "external_ids_breakdown",
+    )
+    metrics = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
+
+    totals_provenance: dict[str, int] = {}
+    for item in result.get("provenance_breakdown", []):
+        for source in item["_id"]:
+            totals_provenance[source] = totals_provenance.get(source, 0) + item["count"]
+
+    metrics["provenance_breakdown"] = {
+        ("_".join(sorted(item["_id"])) if item["_id"] else "none"): item["count"]
+        for item in result.get("provenance_breakdown", [])
+    }
+    metrics["provenance_breakdown"]["totals_provenance"] = dict(
+        sorted(totals_provenance.items(), key=lambda x: x[1], reverse=True)
+    )
+    metrics["open_access_breakdown"] = {item["_id"]: item["count"] for item in result.get("open_access_breakdown", [])}
+    metrics["scimago_quartiles_breakdown"] = {
+        item["_id"]: item["count"] for item in result.get("scimago_quartiles_breakdown", [])
+    }
+    metrics["source_types_breakdown"] = {
+        item["_id"]: item["count"] for item in result.get("source_types_breakdown", [])
+    }
+    metrics["license_type_breakdown"] = {
+        item["_id"]: item["count"] for item in result.get("license_type_breakdown", [])
+    }
+    metrics["external_ids_breakdown"] = {
+        item["_id"]: item["count"] for item in result.get("external_ids_breakdown", [])
+    }
+    metrics["total"] = database["sources"].estimated_document_count()
+    return metrics

--- a/quyca/infrastructure/repositories/info_repository.py
+++ b/quyca/infrastructure/repositories/info_repository.py
@@ -1,5 +1,6 @@
 from quyca.domain.constants.institutions import institutions_list
 from quyca.infrastructure.mongo import database
+from typing import Any
 
 _works_quality_cache: dict | None = None
 _person_quality_cache: dict | None = None
@@ -125,7 +126,7 @@ def _compute_works_quality_metrics() -> dict:
         }
     ]
 
-    result = next(database["works"].aggregate(pipeline, allowDiskUse=True), {})
+    result: dict[str, Any] = next(database["works"].aggregate(pipeline, allowDiskUse=True), {})
 
     non_scalar = (
         "provenance_breakdown",
@@ -134,7 +135,7 @@ def _compute_works_quality_metrics() -> dict:
         "without_impactu_normalization_skipped",
         "without_impactu_by_source",
     )
-    metrics = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
+    metrics: dict[str, Any] = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
 
     totals_provenance: dict[str, int] = {}
     for item in result.get("provenance_breakdown", []):
@@ -239,10 +240,10 @@ def _compute_person_quality_metrics() -> dict:
         }
     ]
 
-    result = next(database["person"].aggregate(pipeline, allowDiskUse=True), {})
+    result: dict[str, Any] = next(database["person"].aggregate(pipeline, allowDiskUse=True), {})
 
     non_scalar = ("provenance_breakdown", "external_ids_breakdown", "with_cedula_scienti", "with_cedula_staff")
-    metrics = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
+    metrics: dict[str, Any] = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
 
     totals_provenance: dict[str, int] = {}
     for item in result.get("provenance_breakdown", []):
@@ -349,10 +350,10 @@ def _compute_affiliations_quality_metrics() -> dict:
         }
     ]
 
-    result = next(database["affiliations"].aggregate(pipeline, allowDiskUse=True), {})
+    result: dict[str, Any] = next(database["affiliations"].aggregate(pipeline, allowDiskUse=True), {})
 
     non_scalar = ("provenance_breakdown", "types_breakdown", "external_ids_breakdown")
-    metrics = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
+    metrics: dict[str, Any] = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
 
     totals_provenance: dict[str, int] = {}
     for item in result.get("provenance_breakdown", []):
@@ -451,7 +452,7 @@ def _compute_sources_quality_metrics() -> dict:
         }
     ]
 
-    result = next(database["sources"].aggregate(pipeline, allowDiskUse=True), {})
+    result: dict[str, Any] = next(database["sources"].aggregate(pipeline, allowDiskUse=True), {})
 
     non_scalar = (
         "open_access_breakdown",
@@ -461,7 +462,7 @@ def _compute_sources_quality_metrics() -> dict:
         "provenance_breakdown",
         "external_ids_breakdown",
     )
-    metrics = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
+    metrics: dict[str, Any] = {key: (result[key][0]["n"] if result.get(key) else 0) for key in result if key not in non_scalar}
 
     totals_provenance: dict[str, int] = {}
     for item in result.get("provenance_breakdown", []):

--- a/tests/feature/ciarp/post_ciarp_upload_test.py
+++ b/tests/feature/ciarp/post_ciarp_upload_test.py
@@ -2,7 +2,10 @@ import io
 from typing import Any, cast
 from unittest.mock import patch
 
+import pandas as pd
 from flask.testing import FlaskClient
+
+from quyca.domain.validators.ciarp_validator import CiarpValidator
 
 
 def auth_cookie(client: FlaskClient) -> None:
@@ -169,3 +172,100 @@ def test_ciarp_upload_email_failed(client: FlaskClient) -> None:
     assert response.status_code == 500
     json_data = cast(dict[str, Any], response.json)
     assert json_data["success"] is False
+
+
+def test_ciarp_validate_columns_rejects_ligature_headers() -> None:
+    df = pd.DataFrame(
+        columns=[
+            "código_unidad_académica",
+            "código_subunidad_académica",
+            "tipo_documento",
+            "identiﬁcación",
+            "año",
+            "título",
+            "idioma",
+            "revista",
+            "editorial",
+            "doi",
+            "issn",
+            "isbn",
+            "volumen",
+            "issue",
+            "primera_página",
+            "última_página",
+            "pais_producto",
+            "entidad_premiadora",
+            "ranking",
+        ]
+    )
+
+    valid, errors, usecols = CiarpValidator.validate_columns(df)
+
+    assert valid is False
+    assert any("Columnas faltantes" in error for error in errors)
+    assert "identificación" not in usecols
+
+
+def test_ciarp_validate_columns_ignores_extra_columns() -> None:
+    df = pd.DataFrame(
+        columns=[
+            "código_unidad_académica",
+            "código_subunidad_académica",
+            "tipo_documento",
+            "identificación",
+            "año",
+            "título",
+            "idioma",
+            "revista",
+            "editorial",
+            "doi",
+            "issn",
+            "isbn",
+            "volumen",
+            "issue",
+            "primera_página",
+            "última_página",
+            "pais_producto",
+            "entidad_premiadora",
+            "ranking",
+            "grupo_de_investigación",
+            "cod_grupo_minciencias",
+            "orcid",
+        ]
+    )
+
+    valid, errors, usecols = CiarpValidator.validate_columns(df)
+
+    assert valid is True
+    assert errors == []
+    assert "grupo_de_investigación" not in usecols
+    assert "orcid" not in usecols
+
+
+def test_ciarp_validate_row_accepts_numeric_text_identification_and_year() -> None:
+    result = CiarpValidator.validate_row(
+        {
+            "código_unidad_académica": "FAC-UNAULA-001",
+            "código_subunidad_académica": "12201",
+            "tipo_documento": "cédula de ciudadanía",
+            "identificación": "168.0",
+            "año": "2024.0",
+            "título": "Un artículo",
+            "idioma": "es",
+            "revista": "Revista X",
+            "editorial": "Editorial X",
+            "doi": "10.1234/test",
+            "issn": "0123-4567",
+            "isbn": "",
+            "volumen": "1",
+            "issue": "1",
+            "primera_página": "1",
+            "última_página": "10",
+            "pais_producto": "CO",
+            "entidad_premiadora": "",
+            "ranking": "1",
+        },
+        0,
+    )
+
+    assert result["errors"] == []

--- a/tests/feature/staff/post_staff_upload_test.py
+++ b/tests/feature/staff/post_staff_upload_test.py
@@ -484,6 +484,61 @@ def test_staff_normalizer_formats_datetime_values() -> None:
     assert cleaned.loc[0, "fecha_final_vinculación"] == "10/12/2025"
 
 
+def test_staff_normalizer_coerces_safe_numeric_text_fields() -> None:
+    normalizer = StaffNormalizerService()
+    df = pd.DataFrame(
+        {
+            "identificación": ["168"],
+            "código_unidad_académica": ["12100"],
+            "código_subunidad_académica": ["12201"],
+        }
+    )
+
+    cleaned = normalizer.clean(df)
+
+    assert cleaned.loc[0, "identificación"] == 168
+    assert cleaned.loc[0, "código_unidad_académica"] == "12100"
+    assert cleaned.loc[0, "código_subunidad_académica"] == "12201"
+    assert cleaned["identificación"].dtype.kind in {"i", "u"}
+
+
+def test_staff_normalizer_coerces_float_like_identification_text() -> None:
+    normalizer = StaffNormalizerService()
+    df = pd.DataFrame({"identificación": ["168.0"]})
+
+    cleaned = normalizer.clean(df)
+
+    assert cleaned.loc[0, "identificación"] == 168
+    assert cleaned["identificación"].dtype.kind in {"i", "u"}
+
+
+def test_document_validator_accepts_float_like_numeric_identification() -> None:
+    errors = StaffValidator.validate_row(
+        {
+            "tipo_documento": "cédula de ciudadanía",
+            "identificación": "168.0",
+            "primer_apellido": "Pérez",
+            "segundo_apellido": "García",
+            "nombres": "Ana",
+            "nivel_académico": "doctorado",
+            "tipo_contrato": "término fijo",
+            "jornada_laboral": "tiempo completo",
+            "categoría_laboral": "profesor titular",
+            "sexo": "mujer",
+            "fecha_nacimiento": "01/01/1980",
+            "fecha_inicial_vinculación": "01/01/2020",
+            "fecha_final_vinculación": "",
+            "código_unidad_académica": "FAC-UNAULA-001",
+            "unidad_académica": "Facultad de Derecho",
+            "código_subunidad_académica": "12201",
+            "subunidad_académica": "Departamento X",
+        },
+        0,
+    )
+
+    assert errors["errors"] == []
+
+
 def test_pdf_report_includes_normalization_section() -> None:
     pdf_repo = PDFRepository()
     captured: dict[str, str] = {}


### PR DESCRIPTION
Adds a new cached endpoint GET /info/quality that reports data completeness
and provenance coverage for works, person, affiliations and sources collections.
Each collection exposes scalar completeness counters, provenance_breakdown (Venn-ready),
and collection-specific breakdowns (types, external_ids, OA status, Scimago quartiles).
Results are cached in-memory — single compute on first request, ~0 cost on subsequent calls.